### PR TITLE
fix: respect saved XML source mode on startup

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -157,7 +157,12 @@ export class Server extends EventEmitter<ServerEvents> {
 
     // Start XML autodetection if enabled and no manual path set
     if (this.config.xmlAutoDetect && !this.config.xmlPath) {
-      this.startAutoDetection();
+      const mode = getAppSettings().getXmlSourceMode();
+      if (mode === 'auto-main' || mode === 'auto-offline') {
+        this.startAutoDetectionWithMode(mode);
+      } else {
+        this.startAutoDetection();
+      }
     }
 
     this.isRunning = true;


### PR DESCRIPTION
## Summary

- Server startup now respects the saved `XmlSourceMode` (auto-main vs auto-offline)
- Previously `start()` always called the generic `startAutoDetection()` which prefers the offline/backup XML copy regardless of the user's mode setting
- Now it calls `startAutoDetectionWithMode()` with the saved mode, so `auto-main` correctly uses only `CurrentEventFile`

Fixes #37

## Test plan

- [x] TypeScript compiles without errors
- [x] All 480 tests pass
- [ ] Manual: Set mode to auto-main, restart server, verify it uses CurrentEventFile (not backup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)