### PR TITLE
fix: read investigation star from PP attribute

### DIFF
--- a/src/protocol/xml-parser.ts
+++ b/src/protocol/xml-parser.ts
@@ -259,7 +259,9 @@ export function parseResults(element: unknown): ResultsMessage | null {
       const betterRunRaw = resultT?.['@_BetterRunNr'];
 
       // Parse IRM (Invalid Result Mark) status
+      // C123 sends DNS/DNF/DSQ in IRM, but sends investigation star (*) in PP attribute
       const irm = String(resultT?.['@_IRM'] ?? '').toUpperCase();
+      const pp = String(resultT?.['@_PP'] ?? '');
 
       const resultRow: ResultRow = {
         rank,
@@ -278,9 +280,14 @@ export function parseResults(element: unknown): ResultsMessage | null {
         behind: String(resultT?.['@_Behind'] ?? ''),
       };
 
-      // Add IRM status if present (DNS, DNF, DSQ, * = under investigation)
-      if (irm === 'DNS' || irm === 'DNF' || irm === 'DSQ' || irm === '*') {
+      // Add IRM status if present (DNS, DNF, DSQ)
+      if (irm === 'DNS' || irm === 'DNF' || irm === 'DSQ') {
         resultRow.status = irm;
+      }
+
+      // Check PP attribute for investigation star (C123 sends * in PP, not IRM)
+      if (!resultRow.status && pp === '*') {
+        resultRow.status = '*';
       }
 
       // Add optional BR1/BR2 fields


### PR DESCRIPTION
## Summary
- C123 TCP protocol sends the investigation star (`*`) in the `PP` attribute, not `IRM`
- Previous fix (69c29de) added `IRM="*"` parsing, but actual data arrives as `PP="*"`
- Now reads `PP` attribute as fallback when `IRM` is empty

## Context
Raw TCP data from C123:
- Investigation result: `IRM="" PP="*"`
- DNS result: `IRM="DNS" PP=""`

## Test plan
- [x] Verified with live C123 TCP stream — `PP="*"` correctly parsed as `status: "*"`
- [x] REST API confirms `status: "*"` for affected bibs
- [x] Scoreboard displays investigation star for affected results

🤖 Generated with [Claude Code](https://claude.com/claude-code)