### PR TITLE
feat: Windows installer with bundled Node.js runtime (#9)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,10 @@ jobs:
     runs-on: windows-latest
     permissions:
       contents: read
+      # Needed to pull @opencanoetiming/timing-design-system from GitHub
+      # Packages. Setting any explicit permission turns all others off, so
+      # we must enumerate both here instead of relying on repo defaults.
+      packages: read
     outputs:
       version: ${{ steps.version.outputs.version }}
       installer-name: ${{ steps.version.outputs.installer-name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,12 @@ jobs:
 
       - name: Stage installer payload
         run: npm run build:installer
+        env:
+          # prepare-installer-payload.js runs `npm ci --omit=dev` inside
+          # build-output/app/, which still needs to authenticate against
+          # npm.pkg.github.com to pull @opencanoetiming/timing-design-system
+          # (a regular — not dev — dependency).
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Verify Inno Setup is available
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,173 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: release-${{ github.ref }}
+  # Cancel concurrent runs only for PRs — main and tag pushes should each
+  # produce their own installer so the rolling preview release always
+  # reflects the latest commit.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  build-installer:
+    name: Build Windows installer
+    runs-on: windows-latest
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      installer-name: ${{ steps.version.outputs.installer-name }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          # Full history so `git rev-parse --short HEAD` in the stage script
+          # can produce a meaningful commit tag for iss-defines.iss.
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          registry-url: 'https://npm.pkg.github.com'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build app
+        run: npm run build
+
+      - name: Stage installer payload
+        run: npm run build:installer
+
+      - name: Verify Inno Setup is available
+        shell: pwsh
+        run: |
+          # Inno Setup 6 is pre-installed on windows-latest runners at this path.
+          # Fall back to choco if that ever changes.
+          $iscc = 'C:\Program Files (x86)\Inno Setup 6\iscc.exe'
+          if (-not (Test-Path $iscc)) {
+            Write-Host "Inno Setup not found at $iscc — installing via choco"
+            choco install innosetup --no-progress -y
+          }
+          Add-Content -Path $env:GITHUB_PATH -Value 'C:\Program Files (x86)\Inno Setup 6'
+
+      - name: Compile installer
+        run: iscc installer/c123-server.iss
+        shell: cmd
+
+      - name: Read package version
+        id: version
+        shell: pwsh
+        run: |
+          $version = (Get-Content package.json | ConvertFrom-Json).version
+          $installerName = "c123-server-setup-$version.exe"
+          "version=$version"              | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          "installer-name=$installerName" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          Write-Host "Version: $version"
+          Write-Host "Installer: $installerName"
+
+      - name: Upload installer artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: c123-server-setup-${{ steps.version.outputs.version }}
+          path: installer/Output/c123-server-setup-*.exe
+          if-no-files-found: error
+          retention-days: 30
+
+  publish-preview:
+    name: Publish preview release
+    needs: build-installer
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Download installer
+        uses: actions/download-artifact@v4
+        with:
+          pattern: c123-server-setup-*
+          merge-multiple: true
+          path: dist-installer
+
+      - name: Delete previous preview release + tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release delete preview --yes --cleanup-tag || true
+
+      - name: Create preview release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMIT_SHA: ${{ github.sha }}
+          INSTALLER_NAME: ${{ needs.build-installer.outputs.installer-name }}
+        run: |
+          SHORT_SHA="${COMMIT_SHA:0:7}"
+          cat > release-notes.md <<'NOTES'
+          Rolling preview build from `main`.
+
+          This is an **unstable preview** automatically rebuilt after every merge to main.
+          For stable releases see the [tagged releases](../../releases?q=v&expanded=true).
+
+          ## Installation
+          1. Download the `c123-server-setup-*.exe` asset below.
+          2. Run it — UAC will prompt for admin privileges.
+          3. The admin dashboard opens automatically at http://localhost:27123.
+          4. The `C123Server` Windows service is registered and started.
+
+          ## Uninstall
+          Settings → Apps → C123 Server → Uninstall.
+          User settings in `%APPDATA%\c123-server\` are preserved across uninstall.
+          NOTES
+          printf '\nBuilt from commit `%s`.\n' "$COMMIT_SHA" >> release-notes.md
+          gh release create preview \
+            --target "$COMMIT_SHA" \
+            --title "Preview build (main @ $SHORT_SHA)" \
+            --prerelease \
+            --notes-file release-notes.md \
+            dist-installer/*.exe
+
+  publish-stable:
+    name: Publish stable release
+    needs: build-installer
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Download installer
+        uses: actions/download-artifact@v4
+        with:
+          pattern: c123-server-setup-*
+          merge-multiple: true
+          path: dist-installer
+
+      - name: Create stable release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ github.ref_name }}" \
+            --target "${{ github.sha }}" \
+            --title "${{ github.ref_name }}" \
+            --generate-notes \
+            dist-installer/*.exe

--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,10 @@ core
 # Test config files (reference only)
 user.config
 
-# Downloaded test fixtures cache
+# Downloaded test fixtures cache + installer runtime cache
 .cache/
+
+# Installer build artefacts
+build-output/
+installer/Output/
+installer/iss-defines.iss

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,39 @@
 # C123 Server - Development Log
 
+## 2026-04-10 — Windows installer (Inno Setup + bundled Node.js)
+
+**Problem:** End users (race organizers) had to clone the repo, install Node.js, run `npm install` + `npm run build`, and only then `npm start -- install`. Too many steps for non-technical users; see issue #9.
+
+**Attempted:**
+- Considered `pkg` / `nexe` / Node.js SEA for a single `.exe`. All fight the ESM `"type": "module"` project setup, the static admin-ui assets, and the `node-windows`/`systray2` optional deps that bundle their own `.exe` binaries. Rejected as fragile.
+- Considered NSIS vs Inno Setup vs WiX. Inno Setup wins on maintainability (Pascal-like scripts), modern default UI, and a proven track record with bundling Node.js — Node.js itself uses Inno Setup for its Windows installer.
+
+**Solution:**
+1. **`scripts/prepare-installer-payload.js`** stages a deterministic `build-output/` tree: `runtime/node.exe` (downloaded once from nodejs.org, cached in `.cache/node-runtime/`) + `app/dist/` + `app/node_modules/` (prod only, via `npm ci --omit=dev --ignore-scripts`) + `LICENSE` + `README.txt`. Writes `installer/iss-defines.iss` with AppVersion from package.json and BuildCommit from git.
+2. **`installer/c123-server.iss`** — Inno Setup 6 script. `[Run]` calls `{app}\runtime\node.exe {app}\app\dist\cli.js install` after files are copied, reusing the existing `WindowsService` wrapper around `node-windows`. `[UninstallRun]` does stop → uninstall → firewall delete in order. Uses LZMA2 ultra64 solid compression — 96 MB uncompressed payload shrinks to a ~23 MB installer.
+3. **`.github/workflows/release.yml`** — windows-latest builds the installer on every push to main (rolling `preview` GitHub Release), on tag push (stable release with auto-generated notes), and on PRs (workflow artifact only). Relies on Inno Setup being pre-installed on `windows-latest` runners with a `choco install` fallback.
+4. **`/api/update-check` endpoint + admin UI banner** — fail-safe GitHub Releases version check, 1-hour cache, 3 s timeout, ignores prereleases so the rolling preview tag does not trigger false upgrade banners. Opt-out via `updateCheck: false` in `settings.json` for closed networks.
+
+**Gotchas learned along the way:**
+
+- **`node-windows` captures `process.execPath` into service XML.** Confirmed by running `node dist/cli.js install` from an elevated shell — the generated `winsw.js` config shows `executable: 'C:\\Program Files\\nodejs\\node.exe'`, the absolute path of whichever `node.exe` ran the CLI. This made the Inno Setup `[Run]` section design critical: it **must** call `{app}\runtime\node.exe` explicitly (not just `node.exe`) with `WorkingDir: {app}\app`, otherwise the service would point at whatever Node the installer happened to find via PATH. With the explicit path, the service config is deterministically bound to our bundled runtime and survives any changes to user PATH (Volta, nvm-windows, global Node uninstall, …).
+
+- **Pascal block comments in `.iss` `[Code]` section don't nest.** Writing `{ mentions {app} here }` as a comment breaks the compiler with `'BEGIN' expected` because the inner `}` closes the comment early. Solution: use `//` line comments in `[Code]` only.
+
+- **`npm ci --omit=dev` leaves empty scope directories behind.** After `--omit=dev --ignore-scripts` in `build-output/app/`, the `node_modules/` contained 99 real prod packages *plus* 15 empty directories for skipped dev scopes (`@eslint/`, `@vitest/`, `@esbuild/`, `@types/`, `@typescript-eslint/`). Zero bytes, but cluttered. The stage script now prunes any empty dir under `node_modules/` after `npm ci`.
+
+- **`node.exe` is ~71 MB, not ~30 MB** as I had estimated from memory. That's the bulk of the installer payload. LZMA2 ultra64 solid compression gets it down to ~23 MB final installer size.
+
+- **GNU tar in Git Bash does NOT extract zip files.** My first stage-script attempt called `tar -xf node.zip`. Works with Windows native bsdtar (`C:\Windows\System32\tar.exe`) but not with MSYS GNU tar, which is what `/usr/bin/tar` resolves to in Git Bash. Switched to PowerShell `Expand-Archive` — always available on Win 10+, same on GitHub Actions `windows-latest`.
+
+**Lesson:** Before bundling anything as a deterministic payload, always verify by running the exact built artefact from the exact expected path (`build-output/runtime/node.exe build-output/app/dist/cli.js run`), not just "it builds". This is what caught the stage-script path issues early.
+
+**Follow-ups discovered during the first real install:**
+
+- **Service detection bug in installer.** First real install triggered a false-positive "service could not be registered automatically" warning at the end of setup, even though the service WAS registered and running. Root cause: `node-windows` mangles the service name (`C123Server` → id `c123server.exe`), and the Pascal `[Code]` helper was querying `sc query C123Server` which finds nothing because that name doesn't exist in SCM — only the display name does. Switched to `RegKeyExists(HKLM\SYSTEM\CurrentControlSet\Services\c123server.exe)` with a retry loop. Much more reliable than sc.exe because the registry write is atomic and immediate.
+
+- **No tray icon in installer mode.** Installer-managed service runs in Session 0, which cannot show tray icons (Windows architectural limit since Vista's Session 0 isolation). `systray2` silently no-ops there. Previous `npm start` usage had a tray because it ran in the user's interactive session. This is not a bug, it's an inherent trade-off of Windows services. Documented in `docs/DEPLOYMENT.md`; tracked as a follow-up improvement in issue #69 ("Tray monitor for installer-managed service" — a separate user-session helper polling `/api/status`).
+
 ## 2025-01-18: Write API Fix - PenaltyCorrection
 
 ### Problem

--- a/README.md
+++ b/README.md
@@ -55,7 +55,24 @@ The server reads Canoe123's `user.config` file to find XML paths:
 
 The offline copy is recommended because it's updated atomically and safer to read.
 
-## Installation
+## Installation (Windows)
+
+Recommended for race organizers — no Node.js required.
+
+1. Download the latest installer from [Releases](https://github.com/OpenCanoeTiming/c123-server/releases/latest):
+   `c123-server-setup-x.y.z.exe`
+2. Double-click to run — UAC will prompt for admin privileges.
+3. The admin dashboard opens at http://localhost:27123.
+4. The `C123Server` Windows service is registered and started automatically. It starts with Windows and restarts on crash.
+
+To uninstall: Settings → Apps → **C123 Server** → Uninstall.
+User settings in `%APPDATA%\c123-server\` are preserved across upgrades and uninstall.
+
+Preview builds from the latest `main` commit are published at [`releases/tag/preview`](https://github.com/OpenCanoeTiming/c123-server/releases/tag/preview) — use these for testing bleeding-edge changes.
+
+See [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) for troubleshooting, service management, and advanced scenarios.
+
+## Installation (from source, for developers)
 
 ```bash
 npm install

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,180 @@
+# Deployment guide
+
+End-user installation, upgrade, uninstall and troubleshooting for C123 Server on Windows.
+
+## Quick install
+
+1. Go to [Releases](https://github.com/OpenCanoeTiming/c123-server/releases/latest).
+2. Download `c123-server-setup-x.y.z.exe`.
+3. Double-click the installer. Windows will show a UAC prompt — accept it.
+4. Walk through the wizard (defaults are fine).
+5. After installation the admin dashboard opens at <http://localhost:27123>.
+
+The installer does the following automatically:
+
+- Copies files to `C:\Program Files\C123 Server\` (portable Node.js runtime + compiled app + production dependencies).
+- Adds a Windows Firewall rule for incoming TCP connections on port 27123 so scoreboards on the local network can connect.
+- Registers the Windows service `C123Server` (starts automatically on boot, restarts on crash).
+- Creates Start Menu shortcuts.
+
+## What gets installed where
+
+| Path | Contents |
+|---|---|
+| `C:\Program Files\C123 Server\runtime\node.exe` | Portable Node.js 20 runtime. Bundled with the installer so the app never depends on the user's own Node.js installation. |
+| `C:\Program Files\C123 Server\app\` | Compiled c123-server application + production `node_modules`. |
+| `C:\Program Files\C123 Server\unins000.exe` | Uninstaller. |
+| `%APPDATA%\c123-server\settings.json` | Your settings (XML path, event name override, client configs, Live-Mini connection). **Preserved across upgrades and uninstall.** |
+
+## Service management
+
+The Windows service is the main process. It runs in the background without any visible window, even when no user is logged in.
+
+> **Note on naming:** The service has **two names**.
+> * **Display name:** `C123Server` — what you see in `services.msc` and `Get-Service`.
+> * **Service ID:** `c123server.exe` — what `sc.exe` and the registry use.
+>
+> This split comes from `node-windows`, which derives the service id from the display name by stripping non-word characters, lowercasing, and appending `.exe`. Both names refer to the same service — use the service id with `sc.exe` commands.
+
+```powershell
+# Check status
+sc.exe query c123server.exe
+
+# Start / stop manually
+sc.exe start c123server.exe
+sc.exe stop c123server.exe
+
+# Services MMC snap-in
+services.msc
+# → find "C123Server" in the list
+```
+
+The service runs as `Local System` by default. Startup type is **Automatic**.
+
+On crash, Windows Service Control Manager restarts the service automatically (3 attempts with exponential backoff — configured by `node-windows`).
+
+## Upgrading
+
+To install a newer version over an existing installation:
+
+1. Download the new installer.
+2. Run it. The installer automatically stops the running `C123Server` service before overwriting files, then re-registers it.
+3. Your settings in `%APPDATA%\c123-server\settings.json` are untouched.
+
+No need to uninstall first. The admin UI shows a banner when a new version is published on GitHub (the check runs hourly against the GitHub Releases API).
+
+### Disabling the update check
+
+On closed networks without outbound access to `api.github.com`, add `"updateCheck": false` to `%APPDATA%\c123-server\settings.json`:
+
+```json
+{
+  "updateCheck": false,
+  ...other settings...
+}
+```
+
+## Uninstalling
+
+**Settings → Apps → C123 Server → Uninstall**, or from the classic Control Panel, or run `C:\Program Files\C123 Server\unins000.exe`.
+
+The uninstaller:
+
+1. Stops the `C123Server` service.
+2. Unregisters the service.
+3. Removes the Windows Firewall rule.
+4. Deletes `C:\Program Files\C123 Server\`.
+
+**Your settings in `%APPDATA%\c123-server\` are NOT deleted.** If you really want a clean wipe, remove that folder manually after uninstall.
+
+## Troubleshooting
+
+### Admin dashboard does not open / `http://localhost:27123` returns connection refused
+
+Check that the service is running:
+
+```powershell
+sc.exe query c123server.exe
+```
+
+If `STATE` is not `RUNNING`:
+
+```powershell
+sc.exe start c123server.exe
+```
+
+If that fails, check the Event Viewer: **Windows Logs → Application**, filter for source `C123Server`. Common causes:
+
+- Port 27123 already in use by another process (`netstat -ano | findstr :27123`).
+- Firewall or antivirus blocking `node.exe`.
+- XML source path unreachable (should only affect data, not the service).
+
+### SmartScreen warning "Windows protected your PC"
+
+The installer is not code-signed yet. This is a known limitation and we'll look at adding a signing certificate in a future release. In the meantime:
+
+1. Click **More info**.
+2. Click **Run anyway**.
+
+The installer source is open, so you can audit it at [github.com/OpenCanoeTiming/c123-server/tree/main/installer](https://github.com/OpenCanoeTiming/c123-server/tree/main/installer) if you want to verify before running.
+
+### "The C123Server service could not be registered automatically"
+
+Shown as a popup at the end of installation. The installer copied files successfully but the post-install service registration step failed. You can register the service manually from an **elevated** command prompt:
+
+```cmd
+"C:\Program Files\C123 Server\runtime\node.exe" "C:\Program Files\C123 Server\app\dist\cli.js" install
+```
+
+If that works, you're done. If it still fails, open an issue with the output.
+
+### No system tray icon after installing
+
+Expected. The installer registers c123-server as a **Windows service**, which runs in *Session 0* — an isolated, non-interactive session that cannot show tray icons (since Windows Vista introduced Session 0 isolation). `systray2` calls `Shell_NotifyIcon`, which silently fails there.
+
+If you previously ran c123-server via `npm start` from a logged-in shell, that process lived in your interactive session and the tray icon worked. The installer-managed service runs in a different security context by design, trading visual feedback for robustness (auto-start on boot, restart on crash, no need to keep a user logged in).
+
+Use the **admin dashboard** (<http://localhost:27123>) for live status, connection counts, event info, and logs. There is a Start Menu shortcut to open it.
+
+A lightweight tray monitor (a separate user-session process polling `/api/status`) is tracked in [issue #69](https://github.com/OpenCanoeTiming/c123-server/issues/69).
+
+### Scoreboards on the LAN cannot connect
+
+The installer adds a firewall rule, but some third-party firewalls / endpoint protection suites ignore Windows Firewall rules and add their own. Check your security software and allow inbound TCP/27123 for `node.exe`.
+
+### Upgrade failed, service stuck in "stopping" state
+
+Rare, but can happen if a scoreboard client holds the WebSocket open during the stop. Hard-kill the service and retry:
+
+```powershell
+sc.exe queryex c123server.exe | findstr PID
+# Note the PID, then:
+taskkill /F /PID <pid>
+sc.exe start c123server.exe
+```
+
+### Uninstalling leaves a stale `C123Server` service
+
+If the uninstaller fails mid-way (e.g. because the service is locked), remove the service manually:
+
+```powershell
+sc.exe stop c123server.exe
+sc.exe delete c123server.exe
+```
+
+Then delete `C:\Program Files\C123 Server\` by hand.
+
+## Running without the installer (advanced)
+
+Developers can skip the installer and run from source — see the main [README.md](../README.md#installation-from-source-for-developers).
+
+The bundled installer is Windows-only. For Linux or macOS deployments, build from source and run `npm start` or `node dist/cli.js run` directly. The Windows service commands (`install` / `uninstall` / `start` / `stop`) require `node-windows` which only works on Windows.
+
+## Reporting issues
+
+- Issues: <https://github.com/OpenCanoeTiming/c123-server/issues>
+- When reporting installer problems, include:
+  - Installer version (visible in the filename)
+  - Output of `sc.exe query c123server.exe`
+  - Relevant Event Viewer entries (Application log, filter by source `C123Server`)
+  - Content of `%APPDATA%\c123-server\settings.json` (redact any API keys first)

--- a/installer/c123-server.iss
+++ b/installer/c123-server.iss
@@ -23,7 +23,14 @@
 #define AppName       "C123 Server"
 #define AppPublisher  "Open Canoe Timing"
 #define AppURL        "https://github.com/OpenCanoeTiming/c123-server"
+; ServiceName is the DISPLAY name visible in services.msc.
+; ServiceId is the ACTUAL service identifier used by sc.exe, the registry,
+; and Get-Service. node-windows derives the id from the name as:
+;   name.replace(/[^\w]/gi, '').toLowerCase() + '.exe'
+; So "C123Server" → "c123server.exe". If ServiceName ever changes in
+; src/service/windows-service.ts, update ServiceId here accordingly.
 #define ServiceName   "C123Server"
+#define ServiceId     "c123server.exe"
 #define ServerPort    "27123"
 #define FirewallRule  "C123 Server"
 
@@ -128,14 +135,44 @@ Filename: "{sys}\netsh.exe"; \
   RunOnceId: "DelFirewallRule"
 
 [Code]
-// Helper: check if a Windows service exists and is queryable via sc.exe.
-// Returns True if `sc query <name>` exits with code 0.
-function IsServiceInstalled(ServiceName: string): Boolean;
-var
-  ResultCode: Integer;
+// Helper: check if a Windows service is registered.
+//
+// We query the registry directly at HKLM\SYSTEM\CurrentControlSet\Services\<Id>
+// rather than shelling out to sc.exe, because:
+//   1. Registry writes by Windows SCM are atomic — no timing windows.
+//   2. No process spawn — immediate, can't time out.
+//   3. No WoW64 redirection issues — HKLM\SYSTEM is shared across views.
+//   4. Reliable regardless of Inno Setup install mode (64-bit vs 32-bit).
+//
+// Important: ServiceId must be the actual service name (as seen by sc.exe),
+// NOT the display name. For c123-server that is "c123server.exe", not
+// "C123Server" — see the ServiceId define at the top of this script.
+//
+// Prior version used "sc query C123Server" which always failed because
+// node-windows registers the service as "c123server.exe" (with id-mangling)
+// while "C123Server" is only the display name.
+function IsServiceInstalled(ServiceId: string): Boolean;
 begin
-  Result := Exec(ExpandConstant('{sys}\sc.exe'), 'query ' + ServiceName,
-    '', SW_HIDE, ewWaitUntilTerminated, ResultCode) and (ResultCode = 0);
+  Result := RegKeyExists(HKEY_LOCAL_MACHINE,
+    'SYSTEM\CurrentControlSet\Services\' + ServiceId);
+end;
+
+// Wait up to TimeoutMs for the service to appear in the registry.
+// node-windows emits its 'install' event slightly before the registry key
+// is fully committed in some scenarios, so a short retry loop removes
+// any remaining race condition between [Run] and CurStepChanged.
+function WaitForServiceInstalled(ServiceId: string; TimeoutMs: Integer): Boolean;
+var
+  Elapsed: Integer;
+begin
+  Result := IsServiceInstalled(ServiceId);
+  Elapsed := 0;
+  while (not Result) and (Elapsed < TimeoutMs) do
+  begin
+    Sleep(500);
+    Elapsed := Elapsed + 500;
+    Result := IsServiceInstalled(ServiceId);
+  end;
 end;
 
 // Before installing, if an older C123 Server is already installed as a service,
@@ -149,23 +186,24 @@ begin
   Result := '';
   NeedsRestart := False;
 
-  if IsServiceInstalled('{#ServiceName}') then
+  if IsServiceInstalled('{#ServiceId}') then
   begin
     Log('Stopping existing {#ServiceName} service before upgrade...');
-    Exec(ExpandConstant('{sys}\sc.exe'), 'stop {#ServiceName}',
+    Exec(ExpandConstant('{sys}\sc.exe'), 'stop {#ServiceId}',
       '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
     Sleep(2000);
   end;
 end;
 
 // After the post-install [Run] step has completed, verify the service is
-// actually registered. If not, warn the user — typically means node-windows
-// or sc.exe failed for some reason (see Event Viewer > Application logs).
+// actually registered. If not (after a short wait), warn the user — this
+// means node-windows or sc.exe failed for some reason and they will need
+// to register manually. See docs/DEPLOYMENT.md for troubleshooting.
 procedure CurStepChanged(CurStep: TSetupStep);
 begin
   if CurStep = ssPostInstall then
   begin
-    if not IsServiceInstalled('{#ServiceName}') then
+    if not WaitForServiceInstalled('{#ServiceId}', 5000) then
     begin
       MsgBox('Warning: The ' + '{#ServiceName}' +
         ' Windows service could not be registered automatically.'#13#10#13#10 +

--- a/installer/c123-server.iss
+++ b/installer/c123-server.iss
@@ -1,0 +1,177 @@
+; Inno Setup script for C123 Server
+; ==================================
+;
+; Build via: npm run build:installer:local
+;
+; The payload at build-output/ is produced by
+; scripts/prepare-installer-payload.js and contains everything we ship:
+; portable Node.js runtime, compiled app, production node_modules, docs.
+;
+; This script:
+;   1. Installs files to {autopf}\C123 Server
+;   2. Adds a Windows Firewall rule for TCP/27123
+;   3. Registers the Windows service by calling our own CLI
+;      ({app}\runtime\node.exe {app}\app\dist\cli.js install) — this reuses
+;      the existing WindowsService implementation in src/service/.
+;   4. On uninstall: stops + uninstalls the service and removes the firewall
+;      rule BEFORE files are deleted (order matters).
+;
+; User settings in %APPDATA%\c123-server\ are NEVER touched.
+
+#include "iss-defines.iss"
+
+#define AppName       "C123 Server"
+#define AppPublisher  "Open Canoe Timing"
+#define AppURL        "https://github.com/OpenCanoeTiming/c123-server"
+#define ServiceName   "C123Server"
+#define ServerPort    "27123"
+#define FirewallRule  "C123 Server"
+
+[Setup]
+; Stable GUID — never change after first release or upgrades will break.
+AppId={{B5C9F3E1-7A2D-4B5E-9F8C-1A3B4D5E6F7A}
+AppName={#AppName}
+AppVersion={#AppVersion}
+AppVerName={#AppName} {#AppVersion}
+AppPublisher={#AppPublisher}
+AppPublisherURL={#AppURL}
+AppSupportURL={#AppURL}/issues
+AppUpdatesURL={#AppURL}/releases
+VersionInfoVersion={#AppVersion}
+VersionInfoDescription={#AppName} installer
+VersionInfoCopyright=Copyright (C) 2025 {#AppPublisher}
+
+DefaultDirName={autopf}\{#AppName}
+DefaultGroupName={#AppName}
+DisableProgramGroupPage=yes
+DisableDirPage=auto
+AllowNoIcons=yes
+
+PrivilegesRequired=admin
+ArchitecturesAllowed=x64compatible
+ArchitecturesInstallIn64BitMode=x64compatible
+
+; Prevent two installer instances from racing on the service/firewall.
+SetupMutex=C123ServerSetupMutex
+CloseApplications=force
+
+; Compress hard — node.exe is ~70 MB and compresses well.
+Compression=lzma2/ultra64
+SolidCompression=yes
+LZMAUseSeparateProcess=yes
+
+OutputDir=Output
+OutputBaseFilename=c123-server-setup-{#AppVersion}
+WizardStyle=modern
+ShowLanguageDialog=auto
+
+LicenseFile=..\build-output\LICENSE
+InfoAfterFile=..\build-output\README.txt
+
+; Uninstaller polish
+UninstallDisplayName={#AppName} {#AppVersion}
+UninstallDisplayIcon={app}\runtime\node.exe
+
+[Languages]
+Name: "en"; MessagesFile: "compiler:Default.isl"
+
+[Files]
+Source: "..\build-output\runtime\*"; DestDir: "{app}\runtime"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "..\build-output\app\*";     DestDir: "{app}\app";     Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "..\build-output\LICENSE";   DestDir: "{app}";         Flags: ignoreversion
+Source: "..\build-output\README.txt"; DestDir: "{app}";        Flags: ignoreversion
+
+[Icons]
+Name: "{group}\{#AppName} Dashboard"; Filename: "http://localhost:{#ServerPort}"
+Name: "{group}\{#AppName} README"; Filename: "{app}\README.txt"
+Name: "{group}\Uninstall {#AppName}"; Filename: "{uninstallexe}"
+
+[Run]
+; 1. Open firewall port for incoming scoreboard/admin connections.
+Filename: "{sys}\netsh.exe"; \
+  Parameters: "advfirewall firewall add rule name=""{#FirewallRule}"" dir=in action=allow protocol=TCP localport={#ServerPort}"; \
+  Flags: runhidden waituntilterminated; \
+  StatusMsg: "Configuring Windows Firewall..."
+
+; 2. Register the Windows service. node-windows captures the absolute path of
+;    the node.exe used here into the service XML — that is exactly why we call
+;    the bundled {app}\runtime\node.exe explicitly. WorkingDir sets the cwd
+;    that the service will run in.
+Filename: "{app}\runtime\node.exe"; \
+  Parameters: """{app}\app\dist\cli.js"" install"; \
+  WorkingDir: "{app}\app"; \
+  Flags: runhidden waituntilterminated; \
+  StatusMsg: "Registering Windows service..."
+
+; 3. Optional: open the admin dashboard in the default browser after install.
+Filename: "http://localhost:{#ServerPort}"; \
+  Description: "Open {#AppName} dashboard in browser"; \
+  Flags: postinstall shellexec nowait skipifsilent unchecked
+
+[UninstallRun]
+; Stop + uninstall service BEFORE files are removed. Order matters.
+Filename: "{app}\runtime\node.exe"; \
+  Parameters: """{app}\app\dist\cli.js"" stop"; \
+  WorkingDir: "{app}\app"; \
+  Flags: runhidden waituntilterminated; \
+  RunOnceId: "StopC123Server"
+
+Filename: "{app}\runtime\node.exe"; \
+  Parameters: """{app}\app\dist\cli.js"" uninstall"; \
+  WorkingDir: "{app}\app"; \
+  Flags: runhidden waituntilterminated; \
+  RunOnceId: "UninstallC123Server"
+
+Filename: "{sys}\netsh.exe"; \
+  Parameters: "advfirewall firewall delete rule name=""{#FirewallRule}"""; \
+  Flags: runhidden waituntilterminated; \
+  RunOnceId: "DelFirewallRule"
+
+[Code]
+// Helper: check if a Windows service exists and is queryable via sc.exe.
+// Returns True if `sc query <name>` exits with code 0.
+function IsServiceInstalled(ServiceName: string): Boolean;
+var
+  ResultCode: Integer;
+begin
+  Result := Exec(ExpandConstant('{sys}\sc.exe'), 'query ' + ServiceName,
+    '', SW_HIDE, ewWaitUntilTerminated, ResultCode) and (ResultCode = 0);
+end;
+
+// Before installing, if an older C123 Server is already installed as a service,
+// stop it so that files in the install directory are no longer locked and can
+// be overwritten. We do NOT uninstall the service here — the new [Run] step
+// will re-register it with the freshly installed binary.
+function PrepareToInstall(var NeedsRestart: Boolean): String;
+var
+  ResultCode: Integer;
+begin
+  Result := '';
+  NeedsRestart := False;
+
+  if IsServiceInstalled('{#ServiceName}') then
+  begin
+    Log('Stopping existing {#ServiceName} service before upgrade...');
+    Exec(ExpandConstant('{sys}\sc.exe'), 'stop {#ServiceName}',
+      '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+    Sleep(2000);
+  end;
+end;
+
+// After the post-install [Run] step has completed, verify the service is
+// actually registered. If not, warn the user — typically means node-windows
+// or sc.exe failed for some reason (see Event Viewer > Application logs).
+procedure CurStepChanged(CurStep: TSetupStep);
+begin
+  if CurStep = ssPostInstall then
+  begin
+    if not IsServiceInstalled('{#ServiceName}') then
+    begin
+      MsgBox('Warning: The ' + '{#ServiceName}' +
+        ' Windows service could not be registered automatically.'#13#10#13#10 +
+        'You can try registering it manually by running this from an elevated command prompt:'#13#10#13#10 +
+        ExpandConstant('"{app}\runtime\node.exe" "{app}\app\dist\cli.js" install'),
+        mbInformation, MB_OK);
+    end;
+  end;
+end;

--- a/installer/c123-server.iss
+++ b/installer/c123-server.iss
@@ -45,8 +45,11 @@ AppPublisherURL={#AppURL}
 AppSupportURL={#AppURL}/issues
 AppUpdatesURL={#AppURL}/releases
 VersionInfoVersion={#AppVersion}
-VersionInfoDescription={#AppName} installer
-VersionInfoCopyright=Copyright (C) 2025 {#AppPublisher}
+; BuildCommit is injected by scripts/prepare-installer-payload.js — surfacing
+; it in the installer's file properties makes field debugging straightforward
+; ("what commit produced this setup.exe?" answerable via right-click → details).
+VersionInfoDescription={#AppName} installer (build {#BuildCommit})
+VersionInfoCopyright=Copyright (C) 2025-2026 {#AppPublisher}
 
 DefaultDirName={autopf}\{#AppName}
 DefaultGroupName={#AppName}
@@ -60,7 +63,11 @@ ArchitecturesInstallIn64BitMode=x64compatible
 
 ; Prevent two installer instances from racing on the service/firewall.
 SetupMutex=C123ServerSetupMutex
-CloseApplications=force
+; We deliberately do NOT set `CloseApplications=force`. Forcing Inno Setup to
+; kill processes holding files in {app} would SIGKILL the running service
+; mid-write. Instead, PrepareToInstall stops + uninstalls the service cleanly
+; and waits for it to fully exit before files are overwritten.
+CloseApplications=no
 
 ; Compress hard — node.exe is ~70 MB and compresses well.
 Compression=lzma2/ultra64
@@ -94,23 +101,29 @@ Name: "{group}\{#AppName} README"; Filename: "{app}\README.txt"
 Name: "{group}\Uninstall {#AppName}"; Filename: "{uninstallexe}"
 
 [Run]
-; 1. Open firewall port for incoming scoreboard/admin connections.
+; 1. Delete any stale firewall rule with the same name. `netsh add rule` is
+;    NOT idempotent — it appends a duplicate on every upgrade. Deleting first
+;    keeps the rule set clean across many upgrades. Non-zero exit when no
+;    such rule exists is harmless — [Run] entries don't abort on exit code.
+Filename: "{sys}\netsh.exe"; \
+  Parameters: "advfirewall firewall delete rule name=""{#FirewallRule}"""; \
+  Flags: runhidden waituntilterminated; \
+  StatusMsg: "Refreshing Windows Firewall rule..."
+
+; 2. Open firewall port for incoming scoreboard/admin connections.
+;    Profile scoping is intentionally broad — OT networks during race events
+;    are assumed trusted and often classified by Windows as Public.
 Filename: "{sys}\netsh.exe"; \
   Parameters: "advfirewall firewall add rule name=""{#FirewallRule}"" dir=in action=allow protocol=TCP localport={#ServerPort}"; \
   Flags: runhidden waituntilterminated; \
   StatusMsg: "Configuring Windows Firewall..."
 
-; 2. Register the Windows service. node-windows captures the absolute path of
-;    the node.exe used here into the service XML — that is exactly why we call
-;    the bundled {app}\runtime\node.exe explicitly. WorkingDir sets the cwd
-;    that the service will run in.
-Filename: "{app}\runtime\node.exe"; \
-  Parameters: """{app}\app\dist\cli.js"" install"; \
-  WorkingDir: "{app}\app"; \
-  Flags: runhidden waituntilterminated; \
-  StatusMsg: "Registering Windows service..."
+; 3. Register the Windows service happens in [Code] CurStepChanged(ssPostInstall)
+;    — NOT here — so we can capture and act on the cli.js exit code. A plain
+;    [Run] entry swallows failures, which we explicitly do not want for the
+;    service-install step.
 
-; 3. Optional: open the admin dashboard in the default browser after install.
+; 4. Optional: open the admin dashboard in the default browser after install.
 Filename: "http://localhost:{#ServerPort}"; \
   Description: "Open {#AppName} dashboard in browser"; \
   Flags: postinstall shellexec nowait skipifsilent unchecked
@@ -157,10 +170,57 @@ begin
     'SYSTEM\CurrentControlSet\Services\' + ServiceId);
 end;
 
+// Check if the service's current state is STOPPED.
+//
+// `sc.exe stop` returns as soon as the stop control has been POSTED to SCM —
+// the actual transition to STOPPED happens asynchronously after the process
+// exits. The previous Sleep(2000) was just a hopeful guess. This helper lets
+// us poll the real state.
+//
+// Strategy: `cmd /c sc query <id> | findstr /C:"STOPPED" >nul` returns
+// exit 0 iff "STOPPED" appears in the output. Exec() gives us that exit
+// code directly — no output parsing needed.
+function IsServiceStopped(ServiceId: string): Boolean;
+var
+  ResultCode: Integer;
+begin
+  Result := Exec(ExpandConstant('{cmd}'),
+    '/c sc query ' + ServiceId + ' | findstr /C:"STOPPED" >nul',
+    '', SW_HIDE, ewWaitUntilTerminated, ResultCode) and (ResultCode = 0);
+end;
+
+function WaitForServiceStopped(ServiceId: string; TimeoutMs: Integer): Boolean;
+var
+  Elapsed: Integer;
+begin
+  Result := IsServiceStopped(ServiceId);
+  Elapsed := 0;
+  while (not Result) and (Elapsed < TimeoutMs) do
+  begin
+    Sleep(500);
+    Elapsed := Elapsed + 500;
+    Result := IsServiceStopped(ServiceId);
+  end;
+end;
+
+function WaitForServiceRemoved(ServiceId: string; TimeoutMs: Integer): Boolean;
+var
+  Elapsed: Integer;
+begin
+  Result := not IsServiceInstalled(ServiceId);
+  Elapsed := 0;
+  while (not Result) and (Elapsed < TimeoutMs) do
+  begin
+    Sleep(500);
+    Elapsed := Elapsed + 500;
+    Result := not IsServiceInstalled(ServiceId);
+  end;
+end;
+
 // Wait up to TimeoutMs for the service to appear in the registry.
 // node-windows emits its 'install' event slightly before the registry key
 // is fully committed in some scenarios, so a short retry loop removes
-// any remaining race condition between [Run] and CurStepChanged.
+// any remaining race condition between install and CurStepChanged.
 function WaitForServiceInstalled(ServiceId: string; TimeoutMs: Integer): Boolean;
 var
   Elapsed: Integer;
@@ -175,41 +235,156 @@ begin
   end;
 end;
 
-// Before installing, if an older C123 Server is already installed as a service,
-// stop it so that files in the install directory are no longer locked and can
-// be overwritten. We do NOT uninstall the service here — the new [Run] step
-// will re-register it with the freshly installed binary.
+// Run the bundled CLI with a single subcommand and return its exit code.
+// Always uses the bundled {app}\runtime\node.exe so the service XML
+// generated by node-windows (which captures process.execPath) is bound to
+// the installed runtime, not whatever node happens to be on PATH.
+function RunCli(Subcommand: string): Integer;
+var
+  AppPath: string;
+  ResultCode: Integer;
+begin
+  AppPath := ExpandConstant('{app}');
+  if not Exec(AppPath + '\runtime\node.exe',
+    '"' + AppPath + '\app\dist\cli.js" ' + Subcommand,
+    AppPath + '\app', SW_HIDE, ewWaitUntilTerminated, ResultCode) then
+  begin
+    // Exec itself failed (e.g. node.exe missing). Treat as non-zero exit.
+    Result := -1;
+    Exit;
+  end;
+  Result := ResultCode;
+end;
+
+// Before installing, if an older C123 Server service exists, take it down
+// cleanly and completely:
+//   1. stop — ask SCM to stop it
+//   2. wait for STOPPED — ensures node.exe has actually exited and released
+//      file locks in {app}
+//   3. uninstall — remove the service registration so the new install step
+//      always creates a fresh service XML pointing at the newly staged
+//      bundled node.exe (node-windows install rejects with "alreadyinstalled"
+//      if we skip this).
+// If any step fails we abort with a clear message — better than proceeding
+// with half-stopped state and getting cryptic "file in use" errors later.
 function PrepareToInstall(var NeedsRestart: Boolean): String;
 var
-  ResultCode: Integer;
+  StopExitCode: Integer;
+  UninstallExitCode: Integer;
 begin
   Result := '';
   NeedsRestart := False;
 
-  if IsServiceInstalled('{#ServiceId}') then
+  if not IsServiceInstalled('{#ServiceId}') then
+    Exit;
+
+  Log('Upgrade path: existing {#ServiceName} service detected, taking it down before overwriting files.');
+
+  // 1. Request stop.
+  Exec(ExpandConstant('{sys}\sc.exe'), 'stop {#ServiceId}',
+    '', SW_HIDE, ewWaitUntilTerminated, StopExitCode);
+  // Exit codes: 0 = stop accepted, 1062 = already stopped. Both fine.
+
+  // 2. Wait for the service to actually reach STOPPED state (15 s budget).
+  if not WaitForServiceStopped('{#ServiceId}', 15000) then
   begin
-    Log('Stopping existing {#ServiceName} service before upgrade...');
-    Exec(ExpandConstant('{sys}\sc.exe'), 'stop {#ServiceId}',
-      '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
-    Sleep(2000);
+    Result := 'The existing C123 Server service did not stop within 15 seconds. ' +
+      'Please stop it manually (services.msc → C123Server → Stop) and run Setup again.';
+    Exit;
   end;
+
+  // 3. Uninstall via our own CLI so node-windows cleans up daemon files too.
+  UninstallExitCode := RunCli('uninstall');
+  if UninstallExitCode <> 0 then
+  begin
+    Result := 'Failed to uninstall the existing C123 Server service (exit code ' +
+      IntToStr(UninstallExitCode) + '). ' +
+      'You may need to remove it manually before upgrading: sc.exe delete {#ServiceId}';
+    Exit;
+  end;
+
+  // 4. Wait for registry entry to disappear (10 s budget).
+  if not WaitForServiceRemoved('{#ServiceId}', 10000) then
+  begin
+    Result := 'The existing C123 Server service was uninstalled but its registry ' +
+      'entry is still present after 10 seconds. This is unusual — please reboot and retry.';
+    Exit;
+  end;
+
+  Log('Existing service removed successfully, proceeding with install.');
 end;
 
-// After the post-install [Run] step has completed, verify the service is
-// actually registered. If not (after a short wait), warn the user — this
-// means node-windows or sc.exe failed for some reason and they will need
-// to register manually. See docs/DEPLOYMENT.md for troubleshooting.
-procedure CurStepChanged(CurStep: TSetupStep);
+// Smoke test: verify the newly registered service references a binary
+// inside the install directory. If node-windows ever captures the wrong
+// node.exe path (e.g. the user's system Node instead of our bundled one),
+// ImagePath will point outside {app}\app — catch that before the user runs
+// into mysterious runtime failures.
+function ImagePathReferencesAppDir(ServiceId: string): Boolean;
+var
+  ImagePath: string;
+  AppDir: string;
 begin
-  if CurStep = ssPostInstall then
+  Result := False;
+  if not RegQueryStringValue(HKEY_LOCAL_MACHINE,
+    'SYSTEM\CurrentControlSet\Services\' + ServiceId,
+    'ImagePath', ImagePath) then
+    Exit;
+
+  // Case-insensitive substring check. Pascal's Pos is case-sensitive, so
+  // lowercase both sides first. Keep the raw ImagePath for logging.
+  AppDir := ExpandConstant('{app}');
+  Log('Service ImagePath = ' + ImagePath);
+  Log('Expected to contain {app} = ' + AppDir);
+  Result := Pos(Lowercase(AppDir), Lowercase(ImagePath)) > 0;
+end;
+
+// After files are copied, register the service via our CLI and capture the
+// exit code. This runs as a [Code] step (not a [Run] entry) specifically so
+// we can act on failure: abort the install with a clear message instead of
+// silently leaving a broken deployment on disk.
+procedure CurStepChanged(CurStep: TSetupStep);
+var
+  InstallExitCode: Integer;
+begin
+  if CurStep <> ssPostInstall then
+    Exit;
+
+  WizardForm.StatusLabel.Caption := 'Registering Windows service...';
+  InstallExitCode := RunCli('install');
+  if InstallExitCode <> 0 then
   begin
-    if not WaitForServiceInstalled('{#ServiceId}', 5000) then
-    begin
-      MsgBox('Warning: The ' + '{#ServiceName}' +
-        ' Windows service could not be registered automatically.'#13#10#13#10 +
-        'You can try registering it manually by running this from an elevated command prompt:'#13#10#13#10 +
-        ExpandConstant('"{app}\runtime\node.exe" "{app}\app\dist\cli.js" install'),
-        mbInformation, MB_OK);
-    end;
+    MsgBox('Setup failed to register the ' + '{#ServiceName}' +
+      ' Windows service (cli.js install exited with code ' +
+      IntToStr(InstallExitCode) + ').'#13#10#13#10 +
+      'The installation will be rolled back. See docs/DEPLOYMENT.md for ' +
+      'troubleshooting, or run this from an elevated command prompt to ' +
+      'reproduce the error:'#13#10#13#10 +
+      ExpandConstant('"{app}\runtime\node.exe" "{app}\app\dist\cli.js" install'),
+      mbCriticalError, MB_OK);
+    Abort;
+  end;
+
+  if not WaitForServiceInstalled('{#ServiceId}', 5000) then
+  begin
+    MsgBox('Setup registered the ' + '{#ServiceName}' +
+      ' service successfully but it did not appear in the registry within 5 seconds.'#13#10#13#10 +
+      'You can try registering it manually from an elevated command prompt:'#13#10#13#10 +
+      ExpandConstant('"{app}\runtime\node.exe" "{app}\app\dist\cli.js" install'),
+      mbInformation, MB_OK);
+    Exit;
+  end;
+
+  // Smoke test: the service's ImagePath must reference the install dir.
+  // Anything else means node-windows captured the wrong node.exe path
+  // during install — guaranteed broken at service start time.
+  if not ImagePathReferencesAppDir('{#ServiceId}') then
+  begin
+    MsgBox('Warning: the ' + '{#ServiceName}' +
+      ' service was registered but its ImagePath does not reference ' +
+      ExpandConstant('{app}') + '.'#13#10#13#10 +
+      'The service will likely fail to start. See Event Viewer → Application ' +
+      'for details, or reinstall after removing any leftover service state ' +
+      '(sc.exe delete {#ServiceId}).',
+      mbError, MB_OK);
   end;
 end;

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "dev": "tsx watch src/index.ts",
     "build": "tsc && node scripts/copy-admin-ui.js",
     "start": "node dist/cli.js",
+    "build:installer": "node scripts/prepare-installer-payload.js",
+    "build:installer:local": "node scripts/prepare-installer-payload.js && iscc installer/c123-server.iss",
     "test": "vitest",
     "lint": "eslint src",
     "typecheck": "tsc --noEmit",

--- a/scripts/prepare-installer-payload.js
+++ b/scripts/prepare-installer-payload.js
@@ -1,0 +1,233 @@
+#!/usr/bin/env node
+
+/**
+ * Prepare installer payload for Inno Setup.
+ *
+ * Creates build-output/ with a deterministic layout matching the final install:
+ *   build-output/
+ *   ├── runtime/
+ *   │   └── node.exe              # portable Node.js runtime (Win x64)
+ *   ├── app/
+ *   │   ├── dist/                 # compiled TypeScript + copied admin-ui
+ *   │   ├── node_modules/         # production dependencies only
+ *   │   └── package.json
+ *   ├── LICENSE
+ *   └── README.txt
+ *
+ * Also writes installer/iss-defines.iss with the current version + commit
+ * so the .iss script can pick them up via #include.
+ *
+ * Node.js runtime is downloaded once and cached in .cache/node-runtime/.
+ * The zip is extracted with PowerShell's Expand-Archive, which is built into
+ * every Windows 10+ machine and GitHub Actions windows-latest runners.
+ *
+ * Intentionally Windows-only — this script produces a Windows installer
+ * payload and is not expected to run on Linux/macOS.
+ */
+
+import {
+  cpSync,
+  createWriteStream,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execSync } from 'node:child_process';
+import { pipeline } from 'node:stream/promises';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const projectRoot = resolve(__dirname, '..');
+
+// Pin Node.js LTS version. Keep in sync with engines.node in package.json.
+const NODE_VERSION = process.env.C123_NODE_RUNTIME_VERSION ?? '20.19.1';
+const NODE_ARCH = 'win-x64';
+const NODE_FOLDER = `node-v${NODE_VERSION}-${NODE_ARCH}`;
+const NODE_ZIP_URL = `https://nodejs.org/dist/v${NODE_VERSION}/${NODE_FOLDER}.zip`;
+
+const BUILD_OUTPUT = join(projectRoot, 'build-output');
+const APP_DIR = join(BUILD_OUTPUT, 'app');
+const RUNTIME_DIR = join(BUILD_OUTPUT, 'runtime');
+const CACHE_ROOT = join(projectRoot, '.cache', 'node-runtime');
+const CACHED_NODE_EXE = join(CACHE_ROOT, NODE_FOLDER, 'node.exe');
+
+function log(msg) {
+  console.log(`[payload] ${msg}`);
+}
+
+function cleanBuildOutput() {
+  log('Cleaning build-output/');
+  rmSync(BUILD_OUTPUT, { recursive: true, force: true });
+  mkdirSync(BUILD_OUTPUT, { recursive: true });
+}
+
+function runBuild() {
+  log('Running npm run build');
+  execSync('npm run build', { cwd: projectRoot, stdio: 'inherit' });
+}
+
+function stageApp() {
+  log('Staging app/');
+  mkdirSync(APP_DIR, { recursive: true });
+
+  // Compiled output (includes dist/admin-ui copied by scripts/copy-admin-ui.js)
+  cpSync(join(projectRoot, 'dist'), join(APP_DIR, 'dist'), { recursive: true });
+
+  // package.json MUST be shipped — "type": "module" is required for ESM resolution at runtime,
+  // and the version field drives the update-check banner.
+  cpSync(join(projectRoot, 'package.json'), join(APP_DIR, 'package.json'));
+  cpSync(join(projectRoot, 'package-lock.json'), join(APP_DIR, 'package-lock.json'));
+
+  // Install prod deps only. --ignore-scripts skips sync-design-system postinstall
+  // which would fail here (it looks for ../timing-design-system/ relative to projectRoot).
+  // Optional deps (node-windows, systray2) are kept because npm defaults to including them.
+  log('Installing production dependencies in app/');
+  execSync('npm ci --omit=dev --ignore-scripts --no-audit --no-fund', {
+    cwd: APP_DIR,
+    stdio: 'inherit',
+  });
+
+  // package-lock.json is not needed in the shipped app.
+  rmSync(join(APP_DIR, 'package-lock.json'), { force: true });
+
+  // npm ci with --omit=dev leaves behind empty scope directories (e.g. @eslint/, @vitest/)
+  // for the skipped dev dependency scopes. They take zero bytes but clutter node_modules —
+  // remove them so the installer payload is clean.
+  pruneEmptyDirs(join(APP_DIR, 'node_modules'));
+}
+
+function pruneEmptyDirs(dir) {
+  if (!existsSync(dir)) return;
+  let removed = 0;
+  for (const name of readdirSync(dir)) {
+    const full = join(dir, name);
+    try {
+      if (readdirSync(full).length === 0) {
+        rmSync(full, { recursive: true, force: true });
+        removed++;
+      }
+    } catch {
+      // not a directory — ignore
+    }
+  }
+  if (removed > 0) log(`Pruned ${removed} empty scope dirs from node_modules`);
+}
+
+async function ensureNodeRuntime() {
+  if (existsSync(CACHED_NODE_EXE)) {
+    log(`Using cached Node.js runtime: ${CACHED_NODE_EXE}`);
+    return;
+  }
+
+  log(`Downloading Node.js ${NODE_VERSION} (${NODE_ARCH})`);
+  mkdirSync(CACHE_ROOT, { recursive: true });
+
+  const response = await fetch(NODE_ZIP_URL);
+  if (!response.ok || !response.body) {
+    throw new Error(`Failed to download ${NODE_ZIP_URL}: HTTP ${response.status}`);
+  }
+
+  const zipPath = join(CACHE_ROOT, `${NODE_FOLDER}.zip`);
+  await pipeline(response.body, createWriteStream(zipPath));
+
+  log('Extracting Node.js zip');
+  // Expand-Archive is built into every Windows 10+ PowerShell install.
+  // -LiteralPath avoids wildcard interpretation of paths containing []/?.
+  execSync(
+    `powershell -NoProfile -NonInteractive -Command "Expand-Archive -LiteralPath '${zipPath}' -DestinationPath '${CACHE_ROOT}' -Force"`,
+    { stdio: 'inherit' },
+  );
+  rmSync(zipPath, { force: true });
+
+  if (!existsSync(CACHED_NODE_EXE)) {
+    throw new Error(`node.exe not found after extraction: ${CACHED_NODE_EXE}`);
+  }
+}
+
+function stageRuntime() {
+  log('Staging runtime/');
+  mkdirSync(RUNTIME_DIR, { recursive: true });
+  cpSync(CACHED_NODE_EXE, join(RUNTIME_DIR, 'node.exe'));
+}
+
+function stageDocs() {
+  log('Staging LICENSE + README.txt');
+  const licenseSrc = join(projectRoot, 'LICENSE');
+  if (existsSync(licenseSrc)) {
+    cpSync(licenseSrc, join(BUILD_OUTPUT, 'LICENSE'));
+  }
+
+  const readmeText = [
+    'C123 Server',
+    '===========',
+    '',
+    'C123 Server has been installed as a Windows service named "C123Server".',
+    'The service starts automatically when Windows boots and restarts on crash.',
+    '',
+    'Admin dashboard:',
+    '  http://localhost:27123',
+    '',
+    'Service management:',
+    '  services.msc  -> find "C123Server"',
+    '  or run:  sc query C123Server',
+    '',
+    'Uninstall:',
+    '  Settings -> Apps -> "C123 Server" -> Uninstall',
+    '',
+    'User settings (preserved across upgrades and uninstall):',
+    '  %APPDATA%\\c123-server\\settings.json',
+    '',
+    'Documentation and issue tracker:',
+    '  https://github.com/OpenCanoeTiming/c123-server',
+    '',
+  ].join('\r\n');
+  writeFileSync(join(BUILD_OUTPUT, 'README.txt'), readmeText);
+}
+
+function writeIssDefines() {
+  const pkg = JSON.parse(readFileSync(join(projectRoot, 'package.json'), 'utf-8'));
+  const version = pkg.version ?? '0.0.0';
+
+  let commit = 'unknown';
+  try {
+    commit = execSync('git rev-parse --short HEAD', { cwd: projectRoot })
+      .toString()
+      .trim();
+  } catch {
+    // not a git checkout — fine
+  }
+
+  const defines = [
+    '; Auto-generated by scripts/prepare-installer-payload.js — do not edit.',
+    `#define AppVersion "${version}"`,
+    `#define BuildCommit "${commit}"`,
+    '',
+  ].join('\r\n');
+
+  const installerDir = join(projectRoot, 'installer');
+  mkdirSync(installerDir, { recursive: true });
+  writeFileSync(join(installerDir, 'iss-defines.iss'), defines);
+  log(`Wrote installer/iss-defines.iss (version=${version}, commit=${commit})`);
+}
+
+async function main() {
+  try {
+    cleanBuildOutput();
+    runBuild();
+    stageApp();
+    await ensureNodeRuntime();
+    stageRuntime();
+    stageDocs();
+    writeIssDefines();
+    log(`Payload ready at: ${BUILD_OUTPUT}`);
+  } catch (err) {
+    console.error(`[payload] FAILED: ${err instanceof Error ? err.message : err}`);
+    process.exit(1);
+  }
+}
+
+main();

--- a/scripts/prepare-installer-payload.js
+++ b/scripts/prepare-installer-payload.js
@@ -43,6 +43,14 @@ import { pipeline } from 'node:stream/promises';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const projectRoot = resolve(__dirname, '..');
 
+// Hard-fail early on non-Windows — the script uses PowerShell Expand-Archive
+// and downloads node.exe. Running it on Linux/macOS would fail opaquely
+// somewhere in the middle.
+if (process.platform !== 'win32') {
+  console.error('[payload] FAILED: This script is Windows-only (runs on Windows or GitHub Actions windows-latest).');
+  process.exit(1);
+}
+
 // Pin Node.js LTS version. Keep in sync with engines.node in package.json.
 const NODE_VERSION = process.env.C123_NODE_RUNTIME_VERSION ?? '20.19.1';
 const NODE_ARCH = 'win-x64';

--- a/src/admin-ui/index.html
+++ b/src/admin-ui/index.html
@@ -47,6 +47,17 @@
     <button class="btn btn-sm" onclick="redetectXmlPath()" style="background: var(--warning); color: var(--bg-body); white-space: nowrap;">Re-detect XML</button>
   </div>
 
+  <!-- Update Available Banner (populated by /api/update-check) -->
+  <div id="updateBanner" class="mismatch-banner mismatch-banner--info" style="display: none;" role="status" aria-live="polite">
+    <div class="mismatch-banner-content">
+      <svg class="mismatch-banner-icon" width="20" height="20" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+        <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm.75-11.25a.75.75 0 00-1.5 0v4.59L7.3 9.24a.75.75 0 00-1.1 1.02l3.25 3.5a.75.75 0 001.1 0l3.25-3.5a.75.75 0 10-1.1-1.02l-1.95 2.1V6.75z" clip-rule="evenodd"/>
+      </svg>
+      <span id="updateMessage">A new version is available</span>
+    </div>
+    <a id="updateLink" href="https://github.com/OpenCanoeTiming/c123-server/releases/latest" target="_blank" rel="noopener" class="btn btn-sm" style="background: var(--info, var(--accent)); color: var(--bg-body); white-space: nowrap; text-decoration: none;">Download</a>
+  </div>
+
   <main class="main-content" id="main-content">
 
   <!-- Event Info Bar (prominent position) -->

--- a/src/admin-ui/main.js
+++ b/src/admin-ui/main.js
@@ -2732,6 +2732,7 @@ function init() {
   loadAssets();
   loadMismatchStatus();
   loadLiveStatus();
+  loadUpdateCheck();
   connectLogWebSocket();
 
   // Periodic refresh
@@ -2739,6 +2740,39 @@ function init() {
   setInterval(loadXmlConfig, 5000);
   setInterval(loadEventName, 5000);
   setInterval(loadClients, 3000);
+  // Update check is hourly — the server caches responses for 1 hour so
+  // more frequent polling would just return the same payload.
+  setInterval(loadUpdateCheck, 60 * 60 * 1000);
+}
+
+/**
+ * Query /api/update-check and show the "new version available" banner if
+ * a newer stable release is published on GitHub. Fail-safe: any error is
+ * silently ignored so the banner stays hidden.
+ */
+async function loadUpdateCheck() {
+  const banner = document.getElementById('updateBanner');
+  const message = document.getElementById('updateMessage');
+  const link = document.getElementById('updateLink');
+  if (!banner || !message || !link) return;
+
+  try {
+    const response = await fetch('/api/update-check');
+    if (!response.ok) return;
+    const data = await response.json();
+
+    if (data && data.isNewer && data.latest) {
+      message.textContent =
+        'A new version is available: v' + data.latest + ' (you have v' + data.current + ')';
+      if (data.url) link.href = data.url;
+      banner.style.display = '';
+    } else {
+      banner.style.display = 'none';
+    }
+  } catch (_err) {
+    // Never break the admin UI because of a failed update check.
+    banner.style.display = 'none';
+  }
 }
 
 // Run initialization when DOM is ready

--- a/src/admin-ui/styles.css
+++ b/src/admin-ui/styles.css
@@ -2840,3 +2840,10 @@ fieldset.modal-section > legend {
 .mismatch-banner-icon {
   flex-shrink: 0;
 }
+
+/* Info variant — used for the update-available banner */
+.mismatch-banner--info {
+  background: color-mix(in srgb, var(--info, var(--accent)) 15%, transparent);
+  border-color: var(--info, var(--accent));
+  color: var(--info, var(--accent));
+}

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -205,6 +205,14 @@ export interface AppSettings {
   eventNameOverride?: string;
   /** TTL in ms for XML data cache — skips file re-read within this window (default: 5000) */
   xmlCacheTtlMs?: number;
+  /**
+   * Enable GitHub release update checks.
+   * When true (default), the admin UI periodically calls /api/update-check
+   * which queries the GitHub Releases API and shows a banner if a newer
+   * version is available. Set to false on closed networks where outbound
+   * HTTPS to api.github.com is not desired.
+   */
+  updateCheck?: boolean;
   /** Timestamp of settings last update */
   lastUpdated?: string;
 
@@ -240,6 +248,7 @@ export const DEFAULT_APP_SETTINGS: AppSettings = {
   xmlAutoDetect: true, // deprecated, kept for backwards compatibility
   xmlAutoDetectInterval: 30000, // 30 seconds
   xmlCacheTtlMs: 5000, // 5 seconds
+  updateCheck: true, // opt-out via settings.json for closed networks
   live: {
     enabled: false,
     serverUrl: null,

--- a/src/unified/UnifiedServer.ts
+++ b/src/unified/UnifiedServer.ts
@@ -20,6 +20,7 @@ import type { CreateEventRequest, EventStatus } from '../live/types.js';
 import type { XmlChangeNotifier } from '../xml/XmlChangeNotifier.js';
 import { getAppSettings, WindowsConfigDetector } from '../config/index.js';
 import type { ClientConfig } from '../config/types.js';
+import { APP_VERSION, compareVersions } from '../utils/appVersion.js';
 
 // Get admin-ui directory path (works for both dev and dist)
 const __filename = fileURLToPath(import.meta.url);
@@ -110,6 +111,19 @@ export class UnifiedServer extends EventEmitter<UnifiedServerEvents> {
   // Live-Mini status broadcast throttling (max 2/s = 500ms)
   private liveStatusLastBroadcast: number = 0;
   private readonly LIVE_STATUS_THROTTLE_MS = 500;
+
+  // Update-check cache (GitHub Releases API response, 1 hour TTL)
+  private updateCheckCache: {
+    current: string;
+    latest: string | null;
+    url: string | null;
+    isNewer: boolean;
+    checkedAt: number;
+    enabled: boolean;
+    error?: string;
+  } | null = null;
+  private readonly UPDATE_CHECK_TTL_MS = 60 * 60 * 1000; // 1 hour
+  private readonly UPDATE_CHECK_TIMEOUT_MS = 3000;
 
   // Registered components
   private eventState: EventState | null = null;
@@ -992,6 +1006,7 @@ export class UnifiedServer extends EventEmitter<UnifiedServerEvents> {
 
     // API routes
     this.app.get('/api/status', this.handleStatus.bind(this));
+    this.app.get('/api/update-check', this.handleUpdateCheck.bind(this));
     this.app.get('/api/sources', this.handleSources.bind(this));
     this.app.get('/api/scoreboards', this.handleScoreboards.bind(this));
     this.app.post('/api/scoreboards/:id/config', this.handleScoreboardConfig.bind(this));
@@ -1122,6 +1137,104 @@ export class UnifiedServer extends EventEmitter<UnifiedServerEvents> {
     };
 
     res.json(response);
+  }
+
+  /**
+   * GET /api/update-check - Check GitHub Releases for a newer version.
+   *
+   * Fail-safe by design: any error (network, timeout, parse, disabled) returns
+   * a 200 response with { latest: null, isNewer: false, error? } so the admin
+   * UI never breaks. Result is cached for 1 hour to avoid hitting the GitHub
+   * API on every dashboard load.
+   *
+   * Disable via settings.json { "updateCheck": false } for closed networks.
+   */
+  private async handleUpdateCheck(_req: Request, res: Response): Promise<void> {
+    const now = Date.now();
+
+    // Serve from cache if fresh
+    if (this.updateCheckCache && now - this.updateCheckCache.checkedAt < this.UPDATE_CHECK_TTL_MS) {
+      res.json(this.updateCheckCache);
+      return;
+    }
+
+    const settings = getAppSettings().get();
+    const enabled = settings.updateCheck !== false;
+
+    // Disabled via settings — return current version only, cache briefly.
+    if (!enabled) {
+      const result = {
+        current: APP_VERSION,
+        latest: null,
+        url: null,
+        isNewer: false,
+        checkedAt: now,
+        enabled: false,
+      };
+      this.updateCheckCache = result;
+      res.json(result);
+      return;
+    }
+
+    try {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), this.UPDATE_CHECK_TIMEOUT_MS);
+
+      const response = await fetch(
+        'https://api.github.com/repos/OpenCanoeTiming/c123-server/releases/latest',
+        {
+          signal: controller.signal,
+          headers: {
+            'User-Agent': `c123-server/${APP_VERSION}`,
+            Accept: 'application/vnd.github+json',
+          },
+        },
+      );
+      clearTimeout(timeout);
+
+      if (!response.ok) {
+        throw new Error(`GitHub API returned HTTP ${response.status}`);
+      }
+
+      const data = (await response.json()) as {
+        tag_name?: string;
+        html_url?: string;
+        prerelease?: boolean;
+      };
+
+      // Ignore preview/prerelease builds — the banner only promotes stable releases.
+      if (data.prerelease) {
+        throw new Error('Latest release is a prerelease, skipping');
+      }
+
+      const latest = (data.tag_name ?? '').replace(/^v/i, '');
+      const isNewer = latest.length > 0 && compareVersions(latest, APP_VERSION) > 0;
+
+      const result = {
+        current: APP_VERSION,
+        latest: latest.length > 0 ? latest : null,
+        url: data.html_url ?? null,
+        isNewer,
+        checkedAt: now,
+        enabled: true,
+      };
+
+      this.updateCheckCache = result;
+      res.json(result);
+    } catch (err) {
+      // Fail-safe: cache the error briefly so we don't hammer GitHub on retry.
+      const result = {
+        current: APP_VERSION,
+        latest: null,
+        url: null,
+        isNewer: false,
+        checkedAt: now,
+        enabled: true,
+        error: err instanceof Error ? err.message : 'unknown error',
+      };
+      this.updateCheckCache = result;
+      res.json(result);
+    }
   }
 
   /**

--- a/src/utils/__tests__/appVersion.test.ts
+++ b/src/utils/__tests__/appVersion.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest';
+import { compareVersions, APP_VERSION } from '../appVersion.js';
+
+describe('compareVersions', () => {
+  describe('main version parts', () => {
+    it('equal versions compare to 0', () => {
+      expect(compareVersions('1.2.3', '1.2.3')).toBe(0);
+      expect(compareVersions('0.0.0', '0.0.0')).toBe(0);
+    });
+
+    it('higher major wins', () => {
+      expect(compareVersions('2.0.0', '1.9.9')).toBe(1);
+      expect(compareVersions('1.0.0', '2.0.0')).toBe(-1);
+    });
+
+    it('higher minor wins when major equal', () => {
+      expect(compareVersions('1.2.0', '1.1.9')).toBe(1);
+      expect(compareVersions('1.1.0', '1.2.0')).toBe(-1);
+    });
+
+    it('higher patch wins when major+minor equal', () => {
+      expect(compareVersions('1.0.2', '1.0.1')).toBe(1);
+      expect(compareVersions('1.0.1', '1.0.2')).toBe(-1);
+    });
+
+    it('missing parts default to 0', () => {
+      expect(compareVersions('1.2', '1.2.0')).toBe(0);
+      expect(compareVersions('1', '1.0.0')).toBe(0);
+      expect(compareVersions('1.2.1', '1.2')).toBe(1);
+    });
+
+    it('strips leading v prefix', () => {
+      expect(compareVersions('v1.2.3', '1.2.3')).toBe(0);
+      expect(compareVersions('V2.0.0', 'v1.9.9')).toBe(1);
+    });
+
+    it('trims whitespace', () => {
+      expect(compareVersions(' 1.2.3 ', '1.2.3')).toBe(0);
+    });
+
+    it('non-numeric segments default to 0', () => {
+      expect(compareVersions('1.x.3', '1.0.3')).toBe(0);
+    });
+  });
+
+  describe('pre-release ordering (semver §11)', () => {
+    it('release > pre-release of the same main version', () => {
+      expect(compareVersions('1.0.0', '1.0.0-rc.1')).toBe(1);
+      expect(compareVersions('1.0.0-rc.1', '1.0.0')).toBe(-1);
+      expect(compareVersions('1.0.0', '1.0.0-alpha')).toBe(1);
+    });
+
+    it('two pre-releases compare their identifiers', () => {
+      expect(compareVersions('1.0.0-alpha', '1.0.0-beta')).toBe(-1);
+      expect(compareVersions('1.0.0-beta', '1.0.0-alpha')).toBe(1);
+      expect(compareVersions('1.0.0-rc.1', '1.0.0-rc.1')).toBe(0);
+    });
+
+    it('numeric pre-release identifiers compare numerically (not lexically)', () => {
+      // The critical bug that plain string comparison would get wrong:
+      // lex: "rc.10" < "rc.2". Numeric: rc.10 > rc.2.
+      expect(compareVersions('1.0.0-rc.10', '1.0.0-rc.2')).toBe(1);
+      expect(compareVersions('1.0.0-rc.2', '1.0.0-rc.10')).toBe(-1);
+      expect(compareVersions('1.0.0-beta.2', '1.0.0-beta.10')).toBe(-1);
+    });
+
+    it('numeric identifiers have lower precedence than non-numeric', () => {
+      // Per semver §11: "1.0.0-1" < "1.0.0-alpha"
+      expect(compareVersions('1.0.0-1', '1.0.0-alpha')).toBe(-1);
+      expect(compareVersions('1.0.0-alpha', '1.0.0-1')).toBe(1);
+    });
+
+    it('longer identifier set wins when shared prefix is equal', () => {
+      expect(compareVersions('1.0.0-alpha', '1.0.0-alpha.1')).toBe(-1);
+      expect(compareVersions('1.0.0-alpha.1', '1.0.0-alpha')).toBe(1);
+    });
+
+    it('follows the canonical semver example chain', () => {
+      // semver.org §11 example:
+      // 1.0.0-alpha < 1.0.0-alpha.1 < 1.0.0-alpha.beta < 1.0.0-beta <
+      // 1.0.0-beta.2 < 1.0.0-beta.11 < 1.0.0-rc.1 < 1.0.0
+      const chain = [
+        '1.0.0-alpha',
+        '1.0.0-alpha.1',
+        '1.0.0-alpha.beta',
+        '1.0.0-beta',
+        '1.0.0-beta.2',
+        '1.0.0-beta.11',
+        '1.0.0-rc.1',
+        '1.0.0',
+      ];
+      for (let i = 0; i < chain.length - 1; i++) {
+        expect(compareVersions(chain[i]!, chain[i + 1]!)).toBe(-1);
+        expect(compareVersions(chain[i + 1]!, chain[i]!)).toBe(1);
+      }
+    });
+  });
+
+  describe('build metadata (semver §10)', () => {
+    it('ignores build metadata for precedence', () => {
+      expect(compareVersions('1.0.0+build.1', '1.0.0+build.2')).toBe(0);
+      expect(compareVersions('1.0.0+abc', '1.0.0')).toBe(0);
+      expect(compareVersions('1.0.0-rc.1+a', '1.0.0-rc.1+b')).toBe(0);
+    });
+  });
+});
+
+describe('APP_VERSION', () => {
+  it('is read from package.json and not the fallback', () => {
+    // Guards against the readVersion() catch path silently returning "0.0.0"
+    // if appVersion.ts is ever moved to a different depth.
+    expect(APP_VERSION).not.toBe('0.0.0');
+    expect(APP_VERSION).toMatch(/^\d+\.\d+\.\d+/);
+  });
+});

--- a/src/utils/appVersion.ts
+++ b/src/utils/appVersion.ts
@@ -1,0 +1,68 @@
+/**
+ * Application version — read once at module load from package.json.
+ *
+ * Works in both dev (tsx runs src/utils/appVersion.ts) and prod (compiled
+ * dist/utils/appVersion.js) because the relative path "../../package.json"
+ * resolves to the project root in both cases.
+ *
+ * Separate from the hardcoded VERSION = '2.0.0' constant in UnifiedServer —
+ * that is the wire-protocol version used in /api/status and /api/info.
+ * APP_VERSION is the semver from package.json used for update checks.
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+function readVersion(): string {
+  try {
+    const pkgPath = join(__dirname, '..', '..', 'package.json');
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8')) as { version?: string };
+    return pkg.version ?? '0.0.0';
+  } catch {
+    return '0.0.0';
+  }
+}
+
+export const APP_VERSION = readVersion();
+
+/**
+ * Compare two semver-like version strings.
+ * Returns 1 if a > b, -1 if a < b, 0 if equal.
+ *
+ * Handles "x.y.z" and "x.y.z-suffix". Pre-release suffixes are sorted
+ * lexicographically and considered LOWER than the corresponding release
+ * (e.g. "1.0.0-rc1" < "1.0.0"). Simple enough for our update-check use case.
+ */
+export function compareVersions(a: string, b: string): number {
+  const [mainA, preA] = splitSemver(a);
+  const [mainB, preB] = splitSemver(b);
+
+  for (let i = 0; i < Math.max(mainA.length, mainB.length); i++) {
+    const x = mainA[i] ?? 0;
+    const y = mainB[i] ?? 0;
+    if (x > y) return 1;
+    if (x < y) return -1;
+  }
+
+  // Main parts equal — pre-release < release < pre-release with higher tag
+  if (preA === '' && preB === '') return 0;
+  if (preA === '') return 1; // "1.0.0" > "1.0.0-rc1"
+  if (preB === '') return -1;
+  return preA < preB ? -1 : preA > preB ? 1 : 0;
+}
+
+function splitSemver(v: string): [number[], string] {
+  const cleaned = v.replace(/^v/i, '').trim();
+  const dashIdx = cleaned.indexOf('-');
+  const mainStr = dashIdx >= 0 ? cleaned.slice(0, dashIdx) : cleaned;
+  const preStr = dashIdx >= 0 ? cleaned.slice(dashIdx + 1) : '';
+  const main = mainStr.split('.').map((p) => {
+    const n = Number(p);
+    return Number.isFinite(n) ? n : 0;
+  });
+  return [main, preStr];
+}

--- a/src/utils/appVersion.ts
+++ b/src/utils/appVersion.ts
@@ -33,9 +33,13 @@ export const APP_VERSION = readVersion();
  * Compare two semver-like version strings.
  * Returns 1 if a > b, -1 if a < b, 0 if equal.
  *
- * Handles "x.y.z" and "x.y.z-suffix". Pre-release suffixes are sorted
- * lexicographically and considered LOWER than the corresponding release
- * (e.g. "1.0.0-rc1" < "1.0.0"). Simple enough for our update-check use case.
+ * Handles "x.y.z" and "x.y.z-pre.release.parts". Pre-release ordering follows
+ * the semver 2.0 spec §11:
+ *   - A version with pre-release has lower precedence than the same without
+ *     ("1.0.0-rc.1" < "1.0.0").
+ *   - Pre-release identifiers are compared dot-separated. Numeric identifiers
+ *     compare numerically (so "rc.2" < "rc.10"), non-numeric lexically,
+ *     numeric < non-numeric, and a longer set wins if all prefix parts equal.
  */
 export function compareVersions(a: string, b: string): number {
   const [mainA, preA] = splitSemver(a);
@@ -49,20 +53,51 @@ export function compareVersions(a: string, b: string): number {
   }
 
   // Main parts equal — pre-release < release < pre-release with higher tag
-  if (preA === '' && preB === '') return 0;
-  if (preA === '') return 1; // "1.0.0" > "1.0.0-rc1"
-  if (preB === '') return -1;
-  return preA < preB ? -1 : preA > preB ? 1 : 0;
+  if (preA.length === 0 && preB.length === 0) return 0;
+  if (preA.length === 0) return 1; // "1.0.0" > "1.0.0-rc.1"
+  if (preB.length === 0) return -1;
+  return comparePreRelease(preA, preB);
 }
 
-function splitSemver(v: string): [number[], string] {
+function comparePreRelease(a: string[], b: string[]): number {
+  const len = Math.min(a.length, b.length);
+  for (let i = 0; i < len; i++) {
+    const cmp = comparePreReleasePart(a[i]!, b[i]!);
+    if (cmp !== 0) return cmp;
+  }
+  // All shared identifiers equal — longer set wins (semver §11).
+  if (a.length < b.length) return -1;
+  if (a.length > b.length) return 1;
+  return 0;
+}
+
+function comparePreReleasePart(a: string, b: string): number {
+  const aNum = /^\d+$/.test(a);
+  const bNum = /^\d+$/.test(b);
+  if (aNum && bNum) {
+    const ai = Number(a);
+    const bi = Number(b);
+    return ai < bi ? -1 : ai > bi ? 1 : 0;
+  }
+  // Per semver §11: numeric identifiers always have lower precedence than
+  // non-numeric (e.g. "1.0.0-1" < "1.0.0-alpha").
+  if (aNum) return -1;
+  if (bNum) return 1;
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+function splitSemver(v: string): [number[], string[]] {
   const cleaned = v.replace(/^v/i, '').trim();
-  const dashIdx = cleaned.indexOf('-');
-  const mainStr = dashIdx >= 0 ? cleaned.slice(0, dashIdx) : cleaned;
-  const preStr = dashIdx >= 0 ? cleaned.slice(dashIdx + 1) : '';
+  // Strip build metadata (ignored for precedence per semver §10).
+  const plusIdx = cleaned.indexOf('+');
+  const noMeta = plusIdx >= 0 ? cleaned.slice(0, plusIdx) : cleaned;
+  const dashIdx = noMeta.indexOf('-');
+  const mainStr = dashIdx >= 0 ? noMeta.slice(0, dashIdx) : noMeta;
+  const preStr = dashIdx >= 0 ? noMeta.slice(dashIdx + 1) : '';
   const main = mainStr.split('.').map((p) => {
     const n = Number(p);
     return Number.isFinite(n) ? n : 0;
   });
-  return [main, preStr];
+  const pre = preStr.length > 0 ? preStr.split('.') : [];
+  return [main, pre];
 }


### PR DESCRIPTION
## Summary

Closes #9.

Adds a proper Windows distribution story for c123-server. End users (race organizers) can now download a single `.exe` installer, double-click it, and get a running Windows service with zero prerequisites — no Node.js, no git clone, no `npm install`, no `npm run build`.

The installer:
- Ships a portable Node.js 20 LTS runtime bundled inside (~71 MB `node.exe`)
- Installs everything under `C:\Program Files\C123 Server\` with admin privileges
- Registers the `C123Server` Windows service via our existing `WindowsService` wrapper (reusing `node-windows`)
- Adds the Windows Firewall rule for TCP/27123
- Creates Start Menu shortcuts for the admin dashboard
- On uninstall, cleanly reverses all of the above but **preserves** `%APPDATA%\c123-server\settings.json`
- Weighs in at ~23 MB after LZMA2 ultra64 solid compression

Chosen tools and their rationale are documented in `DEVLOG.md` — short version: **Inno Setup** (readable Pascal-ish scripts, modern default UI, same installer that Node.js itself ships with) rather than NSIS, WiX, or `pkg`/SEA single-exe approaches.

## What's in this PR (by commit)

| # | Commit | Purpose |
|---|---|---|
| 1 | `chore: add installer payload stage script` | `scripts/prepare-installer-payload.js` stages a deterministic `build-output/` directory with portable Node.js + compiled app + production `node_modules` + docs. Downloads and caches Node runtime. Writes `installer/iss-defines.iss` with version + git commit. |
| 2 | `feat: add Inno Setup installer script` | `installer/c123-server.iss` that consumes the staged payload and produces `c123-server-setup-x.y.z.exe`. Calls `{app}\runtime\node.exe {app}\app\dist\cli.js install` post-install to register the service with the bundled node path captured into service XML. Uninstall flow: stop → uninstall service → remove firewall rule → delete files (in that order). |
| 3 | `ci: add release workflow` | `.github/workflows/release.yml` — builds the installer on `windows-latest` on every push to `main` (rolling `preview` GitHub Release), on tags `v*` (stable release), and on PRs (artifact only). Existing `ci.yml` remains the primary quality gate. |
| 4 | `feat: /api/update-check endpoint and admin UI banner` | Server fetches GitHub Releases API hourly, caches, shows banner in admin UI when a newer stable version is available. Fail-safe — any error keeps the banner hidden so update checks can never break the dashboard. Opt-out via `updateCheck: false` in `settings.json` for closed networks. |
| 5 | `fix(installer): detect service via registry, not sc query` | Uncovered during first real install: `node-windows` mangles service display name `C123Server` into service id `c123server.exe` — so the post-install `sc query C123Server` sanity check always showed a false-positive warning. Rewritten to use `RegKeyExists` on `HKLM\SYSTEM\CurrentControlSet\Services\c123server.exe` with a short retry loop. |
| 6 | `docs: end-user install guide, DEPLOYMENT.md, DEVLOG entry` | README now leads with the end-user install flow; developer source-install moves below. `docs/DEPLOYMENT.md` is a new troubleshooting and lifecycle guide. `DEVLOG.md` records the design decisions and gotchas. |

## Test plan

End-to-end validation on the dev machine (Windows 11, Node 22.14, fresh install scenario):

- [x] `npm run build:installer:local` produces `installer/Output/c123-server-setup-0.1.0.exe` (~23 MB)
- [x] Installer runs, elevates, copies files to `C:\Program Files\C123 Server\`
- [x] `Test-Path HKLM:\SYSTEM\CurrentControlSet\Services\c123server.exe` → **True**
- [x] `Get-Service c123server.exe` → **Running / Automatic**
- [x] `curl http://localhost:27123/api/status` → **200 OK** with real TCP-connected state against a live C123 on the LAN
- [x] No post-install warning dialog (after the `fix(installer)` commit)
- [x] `curl http://localhost:27123/api/update-check` → fail-safe JSON payload (GitHub 404 expected until we ship the first stable release)
- [x] Uninstall via Settings → Apps:
  - [x] Registry key gone (`False`)
  - [x] `C:\Program Files\C123 Server\` gone (`False`)
  - [x] Firewall rule gone (`No rules match`)
  - [x] **`%APPDATA%\c123-server\settings.json` preserved** (`True`) — critical quality property
  - [x] `http://localhost:27123` unreachable

- [ ] Fresh install verified by CI on a clean `windows-latest` runner (will happen when this PR is pushed and the `release.yml` workflow runs)
- [ ] `preview` GitHub Release appears after merge to `main` (new rolling release model)
- [ ] First `v0.2.0` tag produces a stable release after merge

## Known limitations / follow-ups

- **No tray icon in installer mode.** Windows services run in Session 0 and cannot show tray icons (`Shell_NotifyIcon` fails there). Previous `npm start` usage had a tray because it ran in the user's interactive session. Documented in `docs/DEPLOYMENT.md`. Follow-up improvement tracked in #69 — a lightweight user-session tray monitor that polls `/api/status` and displays tray state.
- **Installer is not code-signed.** SmartScreen will show "Unknown publisher" on first run. Documented with a workaround in `docs/DEPLOYMENT.md`. Adding a code-signing certificate is a separate effort.
- The existing `--experimental-specifier-resolution=node` flag in `src/service/windows-service.ts:50` is deprecated in Node 22 but still functional. Cleanup is out of scope for this PR.

## Screenshots

Verified working locally; CI will produce a downloadable installer artifact on the PR for reviewer testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)