### PR TITLE
feat: standalone tray monitor for installer-managed service

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,23 @@
 # C123 Server - Development Log
 
+## 2026-04-11 — Second-opinion review caught three bugs my own review missed (tray monitor, #69)
+
+**Problem:** After writing what I thought was a thorough review of PR #71 (standalone tray monitor), a `/second-opinion` sweep across Gemini 3 Pro and Claude Code (fresh session) independently flagged three user-facing bugs I had missed or waved off as polish.
+
+**Bugs missed in the primary review:**
+1. `TrayManager.openDashboard()` hardcoded `http://localhost:${port}` — so `--target-url http://remote:27123` polled remote but opened localhost. I had praised "port derivation from --target-url" as a *strength* because I only checked that the port was threaded through, not that the URL it was used in was also parameterized.
+2. The `disconnected` source status was rendered as yellow "reconnecting" — conflating a terminal failure (wrong XML path, dead host) with a transient backoff. Operators would see yellow when they should see red.
+3. The `Quit` menu item tooltip hardcoded `'Stop C123 Server'` — in monitor mode, Quit only closes the tray process, but the label implied it stops the service.
+
+**Attempted:** My original review treated all three as minor polish or noted only tangentially. Gemini caught #1 immediately; Claude Code caught all three and connected #2 to an existing convention in `runServer()` that I hadn't cross-referenced.
+
+**Solution:**
+- `TrayManagerConfig` now takes optional `dashboardUrl`, `titleText`, `quitTooltip` overrides. `runTray` threads the full URL through, labels as "C123 Server Monitor", and makes Quit's tooltip explicit about scope.
+- Extracted `src/tray/statusMapping.ts` as a pure function with full unit test coverage. `disconnected` → red (wins over everything else); `connecting` → yellow; empty `raceName` falls through to default via `||` not `??`.
+- Added `%APPDATA%\c123-server\tray.log` so silent `wscript.exe`-launched crashes leave a diagnostic trail (the original PR's "run manually from cmd" advice is fine for known problems but useless when operators don't know anything is wrong).
+
+**Lesson:** A self-review after reading the TrayManager implementation still missed that `openDashboard()` used a hardcoded localhost URL — I had the evidence in my context and wrote it off. Running second-opinion reviewers on non-trivial PRs is cheap and catches the specific class of bug where "I verified X was passed through but not what X was actually used for". Especially valuable when the review is flattering toward the PR (my bias was "this is a clean PR, probably nothing wrong"). Also: **when two independent reviewers flag the same issue on the first pass, treat it as a must-fix, not a suggestion** — both Gemini and Claude Code caught the localhost hardcoding without prompting.
+
 ## 2026-04-10 — Windows installer (Inno Setup + bundled Node.js)
 
 **Problem:** End users (race organizers) had to clone the repo, install Node.js, run `npm install` + `npm run build`, and only then `npm start -- install`. Too many steps for non-technical users; see issue #9.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -128,15 +128,41 @@ Shown as a popup at the end of installation. The installer copied files successf
 
 If that works, you're done. If it still fails, open an issue with the output.
 
-### No system tray icon after installing
+### System tray icon
 
-Expected. The installer registers c123-server as a **Windows service**, which runs in *Session 0* — an isolated, non-interactive session that cannot show tray icons (since Windows Vista introduced Session 0 isolation). `systray2` calls `Shell_NotifyIcon`, which silently fails there.
+The installer ships a **tray monitor** — a lightweight user-session process that polls the installed service over HTTP and reflects its state in the tray icon (green = all good, yellow = a data source is reconnecting, red = server unreachable). Right-click gives you "Open Dashboard" and "Quit".
 
-If you previously ran c123-server via `npm start` from a logged-in shell, that process lived in your interactive session and the tray icon worked. The installer-managed service runs in a different security context by design, trading visual feedback for robustness (auto-start on boot, restart on crash, no need to keep a user logged in).
+The monitor is installed as a shortcut in your user Startup folder (`shell:startup`) and auto-starts at every login. The shortcut target is `wscript.exe %ProgramFiles%\C123 Server\tray-launcher.vbs`, which in turn spawns `node.exe cli.js tray` with no console window.
 
-Use the **admin dashboard** (<http://localhost:27123>) for live status, connection counts, event info, and logs. There is a Start Menu shortcut to open it.
+#### Why a separate process?
 
-A lightweight tray monitor (a separate user-session process polling `/api/status`) is tracked in [issue #69](https://github.com/OpenCanoeTiming/c123-server/issues/69).
+The service itself runs in *Session 0* — an isolated, non-interactive session that cannot show tray icons (a Windows Vista-era security boundary). `systray2` would silently fail there. The monitor is a second process that lives in *your* interactive session and talks to the service only over `http://localhost:27123/api/status`. No IPC, no event-bus coupling, just HTTP polling every 3 seconds.
+
+#### Disabling or moving the tray
+
+- **Disable for one user:** delete the `C123 Server Tray` shortcut from `shell:startup` (press <kbd>Win</kbd>+<kbd>R</kbd>, type `shell:startup`, delete the shortcut).
+- **Disable for all users:** not installed for all users by default — the shortcut is per-user only.
+- **Stop the running tray:** right-click the icon → *Quit*. It will come back at the next login unless you also delete the shortcut.
+
+#### Debugging a missing tray icon
+
+If no icon appears after login, the most common causes are (a) `wscript.exe` is blocked by a security policy, (b) `systray2`'s bundled Go binary is missing or quarantined by AV, or (c) the service on port 27123 is unreachable. To see the actual error, run the tray manually from a command prompt so its stderr is visible:
+
+```cmd
+"C:\Program Files\C123 Server\runtime\node.exe" "C:\Program Files\C123 Server\app\dist\cli.js" tray
+```
+
+Add `--debug` for verbose logging. If the tray launches but immediately turns red, the service is the problem — check `sc.exe query c123server.exe`.
+
+#### Running the tray manually against a non-default port
+
+If you changed the server port in `%APPDATA%\c123-server\settings.json`, the bundled Startup shortcut still polls the default `27123` and will go red. Either (a) revert the port, or (b) replace the shortcut target with:
+
+```cmd
+"C:\Program Files\C123 Server\runtime\node.exe" "C:\Program Files\C123 Server\app\dist\cli.js" tray --target-url http://localhost:28000
+```
+
+— substituting your actual port.
 
 ### Scoreboards on the LAN cannot connect
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -130,13 +130,27 @@ If that works, you're done. If it still fails, open an issue with the output.
 
 ### System tray icon
 
-The installer ships a **tray monitor** — a lightweight user-session process that polls the installed service over HTTP and reflects its state in the tray icon (green = all good, yellow = a data source is reconnecting, red = server unreachable). Right-click gives you "Open Dashboard" and "Quit".
+The installer ships a **tray monitor** — a lightweight user-session process (`C123 Server Monitor`) that polls the installed service over HTTP and reflects its state in the tray icon:
+
+| Icon | Meaning | Typical cause |
+|------|---------|---------------|
+| 🟢 Green | All data sources `connected`, server healthy | Normal |
+| 🟡 Yellow | A source is `connecting` (transient backoff) **or** no sources configured | Race not started, scoreboard in reconnect |
+| 🔴 Red | A source is terminally `disconnected` **or** the server itself is unreachable | Wrong XML path, service stopped, port filtered |
+
+Right-click gives you "Open Dashboard" and "Quit". The menu title reads "C123 Server Monitor" so you can tell it apart from a locally-run `npm start` tray, and the Quit tooltip makes clear that **Quit only closes the monitor — it does NOT stop the underlying service**.
 
 The monitor is installed as a shortcut in your user Startup folder (`shell:startup`) and auto-starts at every login. The shortcut target is `wscript.exe %ProgramFiles%\C123 Server\tray-launcher.vbs`, which in turn spawns `node.exe cli.js tray` with no console window.
 
 #### Why a separate process?
 
 The service itself runs in *Session 0* — an isolated, non-interactive session that cannot show tray icons (a Windows Vista-era security boundary). `systray2` would silently fail there. The monitor is a second process that lives in *your* interactive session and talks to the service only over `http://localhost:27123/api/status`. No IPC, no event-bus coupling, just HTTP polling every 3 seconds.
+
+#### Install-account gotcha (UAC)
+
+The `{userstartup}` shortcut lands in the Startup folder of **whoever runs the installer**. If you install by right-clicking the `.exe` → *Run as administrator* and typing a different admin password at the UAC prompt, the shortcut ends up in the **administrator's** Startup folder — the operator who logs in day-to-day never sees the tray icon.
+
+**Recommendation:** log in as the operator account first, then double-click the installer (UAC will still prompt for admin credentials, but the shortcut is created for the already-logged-in user). If you installed under the wrong account, copy the shortcut manually from `C:\Users\<admin>\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Startup` into the operator's equivalent folder — or run the installer again while logged in as the operator.
 
 #### Disabling or moving the tray
 
@@ -146,13 +160,17 @@ The service itself runs in *Session 0* — an isolated, non-interactive session 
 
 #### Debugging a missing tray icon
 
-If no icon appears after login, the most common causes are (a) `wscript.exe` is blocked by a security policy, (b) `systray2`'s bundled Go binary is missing or quarantined by AV, or (c) the service on port 27123 is unreachable. To see the actual error, run the tray manually from a command prompt so its stderr is visible:
+The tray writes all log output to `%APPDATA%\c123-server\tray.log` (rotated at 512 KB to `tray.log.old`). If the icon doesn't appear, **check that file first** — it captures startup errors even when running under `wscript.exe` with no console.
+
+If the log file is empty or missing, the most common causes are (a) `wscript.exe` is blocked by a security policy, (b) `systray2`'s bundled Go binary is missing or quarantined by AV, or (c) the service on port 27123 is unreachable. To see live output while debugging, run the tray manually from a command prompt so its stderr is visible:
 
 ```cmd
 "C:\Program Files\C123 Server\runtime\node.exe" "C:\Program Files\C123 Server\app\dist\cli.js" tray
 ```
 
 Add `--debug` for verbose logging. If the tray launches but immediately turns red, the service is the problem — check `sc.exe query c123server.exe`.
+
+**If you see two tray icons:** the Startup copy is already running and you launched another manually. Right-click one and Quit, or kill the duplicate `node.exe` from Task Manager. The monitor has no mutex against double-launch.
 
 #### Running the tray manually against a non-default port
 
@@ -162,7 +180,7 @@ If you changed the server port in `%APPDATA%\c123-server\settings.json`, the bun
 "C:\Program Files\C123 Server\runtime\node.exe" "C:\Program Files\C123 Server\app\dist\cli.js" tray --target-url http://localhost:28000
 ```
 
-— substituting your actual port.
+— substituting your actual port. The "Open Dashboard" menu item will honour `--target-url`, so the monitor and the dashboard link stay in sync.
 
 ### Scoreboards on the LAN cannot connect
 

--- a/installer/c123-server.iss
+++ b/installer/c123-server.iss
@@ -94,11 +94,27 @@ Source: "..\build-output\runtime\*"; DestDir: "{app}\runtime"; Flags: ignorevers
 Source: "..\build-output\app\*";     DestDir: "{app}\app";     Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "..\build-output\LICENSE";   DestDir: "{app}";         Flags: ignoreversion
 Source: "..\build-output\README.txt"; DestDir: "{app}";        Flags: ignoreversion
+; Tray monitor launcher (see docs/DEPLOYMENT.md "System tray icon" section).
+; Shipped from installer/ directly — not part of the build-output payload
+; because it's a small hand-maintained script, not a build artefact.
+Source: "tray-launcher.vbs";          DestDir: "{app}";         Flags: ignoreversion
 
 [Icons]
 Name: "{group}\{#AppName} Dashboard"; Filename: "http://localhost:{#ServerPort}"
 Name: "{group}\{#AppName} README"; Filename: "{app}\README.txt"
 Name: "{group}\Uninstall {#AppName}"; Filename: "{uninstallexe}"
+; User-session tray monitor: Inno Setup drops a shortcut in the current
+; user's Startup folder so the tray icon auto-starts at each login in the
+; operator's interactive session (Session 0 services cannot show tray icons,
+; see issue #69).
+;
+; Target is wscript.exe + tray-launcher.vbs — NOT node.exe directly — to
+; avoid a console-window flash every time Windows runs the shortcut.
+Name: "{userstartup}\{#AppName} Tray"; Filename: "{sys}\wscript.exe"; \
+  Parameters: """{app}\tray-launcher.vbs"""; \
+  WorkingDir: "{app}"; \
+  IconFilename: "{app}\runtime\node.exe"; \
+  Comment: "C123 Server tray monitor (polls the installed service)"
 
 [Run]
 ; 1. Delete any stale firewall rule with the same name. `netsh add rule` is

--- a/installer/tray-launcher.vbs
+++ b/installer/tray-launcher.vbs
@@ -1,0 +1,42 @@
+' C123 Server Tray Monitor Launcher
+' =================================
+'
+' Launches the tray monitor via wscript.exe so that node.exe starts with no
+' visible console window. A .lnk pointing directly at node.exe flashes a
+' black console window on every login, which looks unprofessional for a
+' tray app — Node.js on Windows has no "nodew.exe" equivalent (unlike
+' python/pythonw), so a hidden-launcher wrapper is the simplest workaround.
+'
+' This script lives in {app}\tray-launcher.vbs (the install root). It
+' derives the paths to node.exe and cli.js relative to its own location so
+' it keeps working if the user moves the install directory — no hardcoded
+' C:\Program Files\... baked in.
+'
+' sh.Run(cmd, windowStyle, waitOnReturn):
+'   windowStyle = 0     -> SW_HIDE (no window)
+'   waitOnReturn = False -> do not block; return as soon as the process starts
+
+Option Explicit
+
+Dim sh, fso, appDir, nodeExe, cliJs, cmd
+Set sh = CreateObject("WScript.Shell")
+Set fso = CreateObject("Scripting.FileSystemObject")
+
+' Directory containing this .vbs file == install root (== {app} in Inno Setup)
+appDir = fso.GetParentFolderName(WScript.ScriptFullName)
+nodeExe = appDir & "\runtime\node.exe"
+cliJs = appDir & "\app\dist\cli.js"
+
+' Sanity check: bail out quietly if expected files are missing. A silent
+' exit is intentional — this script runs at user login with no UI, so a
+' popup would be more confusing than helpful. If the tray is missing,
+' docs/DEPLOYMENT.md tells the user how to run the tray command manually
+' from cmd to see the actual error.
+If Not fso.FileExists(nodeExe) Then WScript.Quit 1
+If Not fso.FileExists(cliJs) Then WScript.Quit 1
+
+' Run node.exe cli.js tray, hidden, non-blocking.
+' Quote both paths in case the user installed to a path with spaces.
+cmd = """" & nodeExe & """ """ & cliJs & """ tray"
+sh.CurrentDirectory = appDir & "\app"
+sh.Run cmd, 0, False

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,12 +5,27 @@ import { Logger } from './utils/logger.js';
 /**
  * Parse command line arguments
  */
-function parseArgs(): { command: string; config: ServerConfig; debug: boolean; noTray: boolean } {
+interface TrayOptions {
+  targetUrl: string;
+  pollIntervalMs: number;
+}
+
+function parseArgs(): {
+  command: string;
+  config: ServerConfig;
+  debug: boolean;
+  noTray: boolean;
+  tray: TrayOptions;
+} {
   const args = process.argv.slice(2);
   let command = 'run';
   let debug = false;
   let noTray = false;
   const config: ServerConfig = {};
+  const tray: TrayOptions = {
+    targetUrl: 'http://localhost:27123',
+    pollIntervalMs: 3000,
+  };
 
   // Environment variables for port (C123_SERVER_PORT takes precedence over PORT)
   const envPort = process.env.C123_SERVER_PORT || process.env.PORT;
@@ -24,7 +39,14 @@ function parseArgs(): { command: string; config: ServerConfig; debug: boolean; n
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
 
-    if (arg === 'install' || arg === 'uninstall' || arg === 'start' || arg === 'stop' || arg === 'run') {
+    if (
+      arg === 'install' ||
+      arg === 'uninstall' ||
+      arg === 'start' ||
+      arg === 'stop' ||
+      arg === 'run' ||
+      arg === 'tray'
+    ) {
       command = arg;
       continue;
     }
@@ -71,9 +93,20 @@ function parseArgs(): { command: string; config: ServerConfig; debug: boolean; n
     if (arg === '--no-tray') {
       noTray = true;
     }
+
+    if (arg === '--target-url' && args[i + 1]) {
+      tray.targetUrl = args[++i];
+    }
+
+    if (arg === '--poll-interval' && args[i + 1]) {
+      const parsed = parseInt(args[++i], 10);
+      if (!isNaN(parsed) && parsed >= 500) {
+        tray.pollIntervalMs = parsed;
+      }
+    }
   }
 
-  return { command, config, debug, noTray };
+  return { command, config, debug, noTray, tray };
 }
 
 /**
@@ -87,6 +120,7 @@ Usage: c123-server [command] [options]
 
 Commands:
   run         Run the server (default)
+  tray        Run the standalone tray monitor (polls a running server over HTTP)
   install     Install as Windows service
   uninstall   Uninstall Windows service
   start       Start the Windows service
@@ -104,6 +138,10 @@ Options:
   -h, --help          Show this help message
   -v, --version       Show version
 
+Tray-only options (use with \`tray\` command):
+  --target-url <url>   Server URL to poll (default: http://localhost:27123)
+  --poll-interval <ms> Poll interval in milliseconds, min 500 (default: 3000)
+
 Environment variables:
   C123_SERVER_PORT    Server port (overrides default, overridden by --server-port)
   PORT                Fallback for server port (if C123_SERVER_PORT not set)
@@ -112,6 +150,7 @@ Examples:
   c123-server                     # Run with auto-discovery
   c123-server --host 192.168.1.5  # Connect to specific C123
   c123-server install             # Install as Windows service
+  c123-server tray                # Run standalone tray monitor (user session)
 `);
 }
 
@@ -217,6 +256,116 @@ async function runServer(config: ServerConfig, debug: boolean, noTray: boolean):
 }
 
 /**
+ * Run the standalone tray monitor.
+ *
+ * This is a user-session process that polls a running c123-server over HTTP
+ * and reflects its state in a system tray icon. It exists because when
+ * c123-server is installed as a Windows service it runs in Session 0 and
+ * cannot display tray icons itself (architectural limit since Windows Vista).
+ *
+ * The monitor:
+ * - Does NOT start its own server — it only polls an existing one.
+ * - Uses the existing TrayManager driven purely by HTTP polling (no event-bus coupling).
+ * - Survives the server being unreachable (goes red, stays red, explicit Quit is the only exit).
+ * - Uses AbortController with a 2 s timeout so a filtered/hung socket can't stall the poll loop.
+ * - Uses recursive setTimeout instead of setInterval so a slow poll cannot overlap the next one.
+ */
+async function runTray(options: TrayOptions, debug: boolean): Promise<void> {
+  if (debug) {
+    Logger.setLevel('debug');
+  }
+
+  const { TrayManager } = await import('./tray/TrayManager.js');
+
+  // Derive the port used for the "Open Dashboard" menu item from the poll URL
+  // so --target-url http://localhost:28000 also opens the right dashboard.
+  let port = 27123;
+  try {
+    const parsed = new URL(options.targetUrl);
+    if (parsed.port) {
+      port = parseInt(parsed.port, 10);
+    }
+  } catch {
+    // Ignore — fall back to default 27123
+  }
+
+  let stopped = false;
+
+  const shutdown = () => {
+    if (stopped) return;
+    stopped = true;
+    Logger.info('Tray', 'Shutting down tray monitor');
+    tray.stop();
+    process.exit(0);
+  };
+
+  const tray = new TrayManager({ port, onQuit: shutdown });
+
+  const started = await tray.start();
+  if (!started) {
+    Logger.error('Tray', 'Failed to start system tray (systray2 not available or incompatible)');
+    process.exit(1);
+  }
+
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
+
+  Logger.info('Tray', `Tray monitor started — polling ${options.targetUrl}/api/status every ${options.pollIntervalMs} ms`);
+
+  interface StatusResponse {
+    sources?: Array<{ name: string; status: string }>;
+    event?: { raceName?: string | null };
+  }
+
+  const poll = async (): Promise<void> => {
+    if (stopped) return;
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 2000);
+
+    try {
+      const res = await fetch(`${options.targetUrl}/api/status`, {
+        signal: controller.signal,
+      });
+
+      if (!res.ok) {
+        tray.setStatus('error', `Server returned HTTP ${res.status}`);
+      } else {
+        const data = (await res.json()) as StatusResponse;
+        const sources = data.sources ?? [];
+        const bad = sources.filter((s) => s.status !== 'connected');
+
+        if (sources.length === 0) {
+          tray.setStatus('warning', 'No data sources configured');
+        } else if (bad.length === 0) {
+          tray.setStatus('ok', data.event?.raceName ?? 'C123 Server running');
+        } else {
+          const names = bad.map((s) => s.name).join(', ');
+          tray.setStatus('warning', `${bad.length} source(s) reconnecting: ${names}`);
+        }
+      }
+    } catch {
+      // Either AbortError (timeout), network error, or JSON parse error —
+      // all mean "can't talk to server", which is a single user-facing state.
+      tray.setStatus('error', 'Server unreachable');
+    } finally {
+      clearTimeout(timeoutId);
+    }
+
+    if (!stopped) {
+      setTimeout(() => {
+        void poll();
+      }, options.pollIntervalMs);
+    }
+  };
+
+  // Kick off first poll immediately — initial tray state comes from the
+  // TrayManager default ("warning" + "Starting..."), which will be overwritten
+  // by the first poll result a fraction of a second later.
+  void poll();
+}
+
+/**
  * Windows service management
  */
 async function handleServiceCommand(command: string): Promise<void> {
@@ -259,10 +408,12 @@ async function handleServiceCommand(command: string): Promise<void> {
  * Main entry point
  */
 async function main(): Promise<void> {
-  const { command, config, debug, noTray } = parseArgs();
+  const { command, config, debug, noTray, tray } = parseArgs();
 
   if (command === 'run') {
     await runServer(config, debug, noTray);
+  } else if (command === 'tray') {
+    await runTray(tray, debug);
   } else {
     await handleServiceCommand(command);
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,11 @@
 #!/usr/bin/env node
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { format } from 'node:util';
 import { Server, ServerConfig } from './server.js';
 import { Logger } from './utils/logger.js';
+import { mapStatusResponse, type MinimalStatusResponse } from './tray/statusMapping.js';
 
 /**
  * Parse command line arguments
@@ -256,6 +261,96 @@ async function runServer(config: ServerConfig, debug: boolean, noTray: boolean):
 }
 
 /**
+ * Return the C123 Server user-settings directory for the current platform.
+ * Matches AppSettingsManager.getSettingsPath() so both live in the same dir.
+ *   Windows: %APPDATA%\c123-server
+ *   Linux/macOS: ~/.c123-server
+ */
+function getAppDataDir(): string {
+  if (process.platform === 'win32') {
+    const appData = process.env.APPDATA || path.join(os.homedir(), 'AppData', 'Roaming');
+    return path.join(appData, 'c123-server');
+  }
+  return path.join(os.homedir(), '.c123-server');
+}
+
+/**
+ * Tee console.{log,error,warn,debug} to a log file in the app-data dir.
+ *
+ * Why: under `wscript.exe tray-launcher.vbs` stdout/stderr are discarded, so
+ * a silently crashing tray at login leaves zero diagnostic trail. This patch
+ * intercepts at the console level (rather than replacing Logger) because
+ * Logger already writes through console.*, so we catch all log output with
+ * minimal surface area.
+ *
+ * Rotation: on startup, if the existing log is larger than LOG_ROTATE_SIZE
+ * bytes, rename it to `.old` (overwriting any prior `.old`). This is a
+ * single-generation rotation — good enough for a human operator debugging a
+ * startup failure, and never grows unbounded.
+ *
+ * @returns the log file path, or null if setup failed (directory not writable etc.)
+ */
+function setupTrayFileLog(): string | null {
+  const LOG_ROTATE_SIZE = 512 * 1024; // 512 KB
+  try {
+    const dir = getAppDataDir();
+    fs.mkdirSync(dir, { recursive: true });
+    const logPath = path.join(dir, 'tray.log');
+
+    try {
+      if (fs.statSync(logPath).size > LOG_ROTATE_SIZE) {
+        fs.renameSync(logPath, logPath + '.old');
+      }
+    } catch {
+      // File doesn't exist yet — nothing to rotate.
+    }
+
+    const origLog = console.log.bind(console);
+    const origError = console.error.bind(console);
+    const origWarn = console.warn.bind(console);
+    const origDebug = console.debug.bind(console);
+
+    // Strip ANSI escape codes so the file stays readable in Notepad/less.
+    // Colors should already be off under wscript (no TTY), but users may
+    // also run `node cli.js tray` from cmd where colors ARE on — keep
+    // the file consistent in both cases. The control char in the regex
+    // is intentional, hence the eslint disable.
+    // eslint-disable-next-line no-control-regex
+    const ansiEscapeRegex = /\x1b\[[0-9;]*m/g;
+
+    const writeToFile = (...args: unknown[]): void => {
+      try {
+        const line = format(...args).replace(ansiEscapeRegex, '');
+        fs.appendFileSync(logPath, line + '\n');
+      } catch {
+        // Logging itself failed — nothing useful we can do.
+      }
+    };
+
+    console.log = (...args: unknown[]) => {
+      origLog(...args);
+      writeToFile(...args);
+    };
+    console.error = (...args: unknown[]) => {
+      origError(...args);
+      writeToFile(...args);
+    };
+    console.warn = (...args: unknown[]) => {
+      origWarn(...args);
+      writeToFile(...args);
+    };
+    console.debug = (...args: unknown[]) => {
+      origDebug(...args);
+      writeToFile(...args);
+    };
+
+    return logPath;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Run the standalone tray monitor.
  *
  * This is a user-session process that polls a running c123-server over HTTP
@@ -269,29 +364,50 @@ async function runServer(config: ServerConfig, debug: boolean, noTray: boolean):
  * - Survives the server being unreachable (goes red, stays red, explicit Quit is the only exit).
  * - Uses AbortController with a 2 s timeout so a filtered/hung socket can't stall the poll loop.
  * - Uses recursive setTimeout instead of setInterval so a slow poll cannot overlap the next one.
+ * - Parameterizes TrayManager labels so "Quit" and the menu title make clear
+ *   it's the MONITOR being stopped, not the underlying service.
+ * - Tees all log output to `${APPDATA}/c123-server/tray.log` so a silent
+ *   crash under `wscript.exe` still leaves a diagnostic trail.
  */
 async function runTray(options: TrayOptions, debug: boolean): Promise<void> {
+  // Set up file logging BEFORE anything else so startup errors are captured.
+  const logPath = setupTrayFileLog();
+
   if (debug) {
     Logger.setLevel('debug');
   }
 
-  const { TrayManager } = await import('./tray/TrayManager.js');
-
-  // Derive the port used for the "Open Dashboard" menu item from the poll URL
-  // so --target-url http://localhost:28000 also opens the right dashboard.
-  let port = 27123;
+  // Parse & normalize the target URL up front.
+  // - `origin` gives us a clean scheme+host+port string for both the dashboard
+  //   URL and the status endpoint (handles trailing slashes, no-port cases, etc.).
+  // - If the user passes an invalid URL, fail cleanly with a helpful message
+  //   rather than hitting the generic fetch() failure path every 3 s.
+  let parsedUrl: URL;
   try {
-    const parsed = new URL(options.targetUrl);
-    if (parsed.port) {
-      port = parseInt(parsed.port, 10);
-    }
+    parsedUrl = new URL(options.targetUrl);
   } catch {
-    // Ignore — fall back to default 27123
+    Logger.error('Tray', `Invalid --target-url: "${options.targetUrl}"`);
+    process.exit(1);
   }
+  const dashboardUrl = parsedUrl.origin; // e.g. "http://localhost:27123"
+  const statusUrl = new URL('/api/status', parsedUrl).toString();
+
+  // Still keep a numeric port for the existing TrayManagerConfig.port field
+  // (dashboardUrl overrides it in practice). Fall back to 80/443/27123 in that
+  // order if the URL has no explicit port.
+  const port = parsedUrl.port
+    ? parseInt(parsedUrl.port, 10)
+    : parsedUrl.protocol === 'https:'
+      ? 443
+      : parsedUrl.protocol === 'http:'
+        ? 80
+        : 27123;
+
+  const { TrayManager } = await import('./tray/TrayManager.js');
 
   let stopped = false;
 
-  const shutdown = () => {
+  const shutdown = (): void => {
     if (stopped) return;
     stopped = true;
     Logger.info('Tray', 'Shutting down tray monitor');
@@ -299,7 +415,13 @@ async function runTray(options: TrayOptions, debug: boolean): Promise<void> {
     process.exit(0);
   };
 
-  const tray = new TrayManager({ port, onQuit: shutdown });
+  const tray = new TrayManager({
+    port,
+    dashboardUrl,
+    titleText: 'C123 Server Monitor',
+    quitTooltip: 'Close the monitor (server keeps running)',
+    onQuit: shutdown,
+  });
 
   const started = await tray.start();
   if (!started) {
@@ -310,11 +432,12 @@ async function runTray(options: TrayOptions, debug: boolean): Promise<void> {
   process.on('SIGINT', shutdown);
   process.on('SIGTERM', shutdown);
 
-  Logger.info('Tray', `Tray monitor started — polling ${options.targetUrl}/api/status every ${options.pollIntervalMs} ms`);
-
-  interface StatusResponse {
-    sources?: Array<{ name: string; status: string }>;
-    event?: { raceName?: string | null };
+  Logger.info(
+    'Tray',
+    `Tray monitor started — polling ${statusUrl} every ${options.pollIntervalMs} ms`,
+  );
+  if (logPath) {
+    Logger.info('Tray', `Log file: ${logPath}`);
   }
 
   const poll = async (): Promise<void> => {
@@ -324,30 +447,21 @@ async function runTray(options: TrayOptions, debug: boolean): Promise<void> {
     const timeoutId = setTimeout(() => controller.abort(), 2000);
 
     try {
-      const res = await fetch(`${options.targetUrl}/api/status`, {
-        signal: controller.signal,
-      });
+      const res = await fetch(statusUrl, { signal: controller.signal });
 
       if (!res.ok) {
-        tray.setStatus('error', `Server returned HTTP ${res.status}`);
+        const { status, message } = mapStatusResponse(null, `Server returned HTTP ${res.status}`);
+        tray.setStatus(status, message);
       } else {
-        const data = (await res.json()) as StatusResponse;
-        const sources = data.sources ?? [];
-        const bad = sources.filter((s) => s.status !== 'connected');
-
-        if (sources.length === 0) {
-          tray.setStatus('warning', 'No data sources configured');
-        } else if (bad.length === 0) {
-          tray.setStatus('ok', data.event?.raceName ?? 'C123 Server running');
-        } else {
-          const names = bad.map((s) => s.name).join(', ');
-          tray.setStatus('warning', `${bad.length} source(s) reconnecting: ${names}`);
-        }
+        const data = (await res.json()) as MinimalStatusResponse;
+        const { status, message } = mapStatusResponse(data);
+        tray.setStatus(status, message);
       }
     } catch {
       // Either AbortError (timeout), network error, or JSON parse error —
       // all mean "can't talk to server", which is a single user-facing state.
-      tray.setStatus('error', 'Server unreachable');
+      const { status, message } = mapStatusResponse(null);
+      tray.setStatus(status, message);
     } finally {
       clearTimeout(timeoutId);
     }

--- a/src/tray/TrayManager.ts
+++ b/src/tray/TrayManager.ts
@@ -5,8 +5,27 @@ import { getIcon, type TrayStatus } from './icons.js';
 export type { TrayStatus } from './icons.js';
 
 export interface TrayManagerConfig {
-  /** Server port for dashboard URL */
+  /** Server port — used to build `http://localhost:${port}` if dashboardUrl is not given */
   port: number;
+  /**
+   * Full dashboard URL. Overrides the default `http://localhost:${port}`.
+   * Set this in the standalone tray monitor so "Open Dashboard" opens the
+   * actual polled server (not a hardcoded localhost) when --target-url points
+   * at a non-default host or port.
+   */
+  dashboardUrl?: string;
+  /**
+   * Title shown as the menu header and in the tray tooltip prefix.
+   * Default: "C123 Server". The standalone tray monitor overrides this to
+   * "C123 Server Monitor" so users can tell the processes apart.
+   */
+  titleText?: string;
+  /**
+   * Tooltip on the Quit menu item. Default: "Stop C123 Server".
+   * The standalone tray monitor overrides this to make clear that Quit only
+   * closes the monitor, not the underlying service.
+   */
+  quitTooltip?: string;
   /** Called when user clicks Quit in the tray menu */
   onQuit: () => void;
 }
@@ -55,7 +74,7 @@ export class TrayManager {
         menu: {
           icon,
           title: '',
-          tooltip: 'C123 Server',
+          tooltip: this.getTitleText(),
           items: this.buildMenuItems(),
         },
         debug: false,
@@ -84,6 +103,20 @@ export class TrayManager {
   }
 
   /**
+   * Get the configured title text (falls back to "C123 Server").
+   */
+  private getTitleText(): string {
+    return this.config.titleText ?? 'C123 Server';
+  }
+
+  /**
+   * Get the configured dashboard URL (falls back to localhost:port).
+   */
+  private getDashboardUrl(): string {
+    return this.config.dashboardUrl ?? `http://localhost:${this.config.port}`;
+  }
+
+  /**
    * Build the full menu items array for the current state.
    */
   private buildMenuItems(): Array<{ title: string; tooltip: string; enabled: boolean }> {
@@ -91,11 +124,14 @@ export class TrayManager {
       ? this.statusMessage.substring(0, 77) + '...'
       : this.statusMessage;
 
+    const dashboardUrl = this.getDashboardUrl();
+    const quitTooltip = this.config.quitTooltip ?? 'Stop C123 Server';
+
     return [
-      { title: 'C123 Server', tooltip: '', enabled: false },
+      { title: this.getTitleText(), tooltip: '', enabled: false },
       { title: `Status: ${truncated}`, tooltip: '', enabled: false },
-      { title: 'Open Dashboard', tooltip: `Open http://localhost:${this.config.port}`, enabled: true },
-      { title: 'Quit', tooltip: 'Stop C123 Server', enabled: true },
+      { title: 'Open Dashboard', tooltip: `Open ${dashboardUrl}`, enabled: true },
+      { title: 'Quit', tooltip: quitTooltip, enabled: true },
     ];
   }
 
@@ -122,7 +158,7 @@ export class TrayManager {
       menu: {
         icon,
         title: '',
-        tooltip: `C123 Server - ${truncated}`,
+        tooltip: `${this.getTitleText()} - ${truncated}`,
         items: this.buildMenuItems(),
       },
     });
@@ -172,7 +208,7 @@ export class TrayManager {
    * Open the admin dashboard in the default browser.
    */
   private openDashboard(): void {
-    const url = `http://localhost:${this.config.port}`;
+    const url = this.getDashboardUrl();
 
     let command: string;
     switch (process.platform) {

--- a/src/tray/__tests__/TrayManager.test.ts
+++ b/src/tray/__tests__/TrayManager.test.ts
@@ -234,4 +234,101 @@ describe('TrayManager', () => {
       expect(state.message).toBe('Starting...');
     });
   });
+
+  describe('monitor-mode config overrides', () => {
+    afterEach(() => {
+      // Each test in this block constructs its own tray — stop it individually
+      // so we don't leak between tests. The outer afterEach also runs against
+      // the top-level `tray`, which is harmless (stop is idempotent).
+    });
+
+    it('uses titleText override in the menu header and tray tooltip', async () => {
+      const monitorTray = new TrayManager({
+        port: 27123,
+        titleText: 'C123 Server Monitor',
+        onQuit,
+      });
+      await monitorTray.start();
+
+      const config = MockSysTray.lastOptions as {
+        menu: { tooltip: string; items: Array<{ title: string }> };
+      };
+      expect(config.menu.tooltip).toBe('C123 Server Monitor');
+      expect(config.menu.items[0].title).toBe('C123 Server Monitor');
+      monitorTray.stop();
+    });
+
+    it('uses quitTooltip override on the Quit menu item', async () => {
+      const monitorTray = new TrayManager({
+        port: 27123,
+        quitTooltip: 'Close the monitor (server keeps running)',
+        onQuit,
+      });
+      await monitorTray.start();
+
+      const config = MockSysTray.lastOptions as {
+        menu: { items: Array<{ title: string; tooltip: string }> };
+      };
+      const quitItem = config.menu.items.find((i) => i.title === 'Quit')!;
+      expect(quitItem.tooltip).toBe('Close the monitor (server keeps running)');
+      monitorTray.stop();
+    });
+
+    it('uses dashboardUrl override in the Open Dashboard tooltip and browser launch', async () => {
+      const monitorTray = new TrayManager({
+        port: 27123,
+        dashboardUrl: 'http://192.168.1.50:28000',
+        onQuit,
+      });
+      await monitorTray.start();
+
+      const config = MockSysTray.lastOptions as {
+        menu: { items: Array<{ title: string; tooltip: string }> };
+      };
+      const dashItem = config.menu.items.find((i) => i.title === 'Open Dashboard')!;
+      expect(dashItem.tooltip).toBe('Open http://192.168.1.50:28000');
+
+      // Clicking the menu item should open the override URL, not localhost
+      const clickHandler = mockOnClick.mock.calls[0][0];
+      clickHandler({
+        type: 'clicked',
+        seq_id: 2,
+        item: { title: 'Open Dashboard', tooltip: '' },
+      });
+
+      const execMock = vi.mocked(childProcess.exec);
+      const execCall = execMock.mock.calls[0][0] as string;
+      expect(execCall).toContain('http://192.168.1.50:28000');
+      expect(execCall).not.toContain('localhost');
+      monitorTray.stop();
+    });
+
+    it('falls back to localhost:port when dashboardUrl is not provided', async () => {
+      const defaultTray = new TrayManager({ port: 28000, onQuit });
+      await defaultTray.start();
+
+      const config = MockSysTray.lastOptions as {
+        menu: { items: Array<{ title: string; tooltip: string }> };
+      };
+      const dashItem = config.menu.items.find((i) => i.title === 'Open Dashboard')!;
+      expect(dashItem.tooltip).toBe('Open http://localhost:28000');
+      defaultTray.stop();
+    });
+
+    it('falls back to defaults when no overrides are provided (backward compat)', async () => {
+      // Plain port-only config should still render exactly as before so the
+      // in-process tray (runServer) is unaffected by the refactor.
+      const config = MockSysTray.lastOptions as null;
+      expect(config).toBeNull(); // Not started yet in this test — just sanity
+
+      await tray.start(); // The top-level tray uses the old-style config
+      const startedConfig = MockSysTray.lastOptions as {
+        menu: { tooltip: string; items: Array<{ title: string; tooltip: string }> };
+      };
+      expect(startedConfig.menu.tooltip).toBe('C123 Server');
+      expect(startedConfig.menu.items[0].title).toBe('C123 Server');
+      const quitItem = startedConfig.menu.items.find((i) => i.title === 'Quit')!;
+      expect(quitItem.tooltip).toBe('Stop C123 Server');
+    });
+  });
 });

--- a/src/tray/__tests__/statusMapping.test.ts
+++ b/src/tray/__tests__/statusMapping.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from 'vitest';
+import { mapStatusResponse, type MinimalStatusResponse } from '../statusMapping.js';
+import type { SourceStatusInfo } from '../../admin/types.js';
+
+function makeSource(name: string, status: SourceStatusInfo['status']): SourceStatusInfo {
+  return { name, type: 'tcp', status };
+}
+
+function makeResponse(
+  sources: SourceStatusInfo[],
+  raceName: string | null = null,
+): MinimalStatusResponse {
+  return {
+    sources,
+    event: {
+      currentRaceId: null,
+      raceName,
+      onCourseCount: 0,
+      resultsCount: 0,
+    },
+  };
+}
+
+describe('mapStatusResponse', () => {
+  describe('fetch failures', () => {
+    it('returns error with custom message when fetchError is set', () => {
+      const result = mapStatusResponse(null, 'Server returned HTTP 503');
+      expect(result).toEqual({ status: 'error', message: 'Server returned HTTP 503' });
+    });
+
+    it('returns error with "Server unreachable" when data is null and no fetchError', () => {
+      const result = mapStatusResponse(null);
+      expect(result).toEqual({ status: 'error', message: 'Server unreachable' });
+    });
+
+    it('prefers fetchError over data when both are provided', () => {
+      const data = makeResponse([makeSource('TCP', 'connected')]);
+      const result = mapStatusResponse(data, 'Timeout');
+      expect(result.status).toBe('error');
+      expect(result.message).toBe('Timeout');
+    });
+  });
+
+  describe('no sources configured', () => {
+    it('returns warning when sources array is empty', () => {
+      const result = mapStatusResponse(makeResponse([]));
+      expect(result).toEqual({ status: 'warning', message: 'No data sources configured' });
+    });
+  });
+
+  describe('all connected (ok)', () => {
+    it('returns ok with raceName when present', () => {
+      const data = makeResponse(
+        [makeSource('TCP', 'connected'), makeSource('XML', 'connected')],
+        'Men K1 Final',
+      );
+      expect(mapStatusResponse(data)).toEqual({ status: 'ok', message: 'Men K1 Final' });
+    });
+
+    it('returns ok with default message when raceName is null', () => {
+      const data = makeResponse([makeSource('TCP', 'connected')], null);
+      expect(mapStatusResponse(data)).toEqual({
+        status: 'ok',
+        message: 'C123 Server running',
+      });
+    });
+
+    it('returns ok with default message when raceName is an empty string (|| not ??)', () => {
+      // Regression: `??` would have kept the empty string and produced a
+      // blank "Status: " line; `||` correctly falls through.
+      const data = makeResponse([makeSource('TCP', 'connected')], '');
+      expect(mapStatusResponse(data)).toEqual({
+        status: 'ok',
+        message: 'C123 Server running',
+      });
+    });
+  });
+
+  describe('connecting (warning)', () => {
+    it('returns warning when a single source is connecting', () => {
+      const data = makeResponse([
+        makeSource('TCP', 'connecting'),
+        makeSource('XML', 'connected'),
+      ]);
+      expect(mapStatusResponse(data)).toEqual({
+        status: 'warning',
+        message: '1 source(s) reconnecting: TCP',
+      });
+    });
+
+    it('lists all connecting source names', () => {
+      const data = makeResponse([
+        makeSource('TCP', 'connecting'),
+        makeSource('UDP', 'connecting'),
+        makeSource('XML', 'connected'),
+      ]);
+      expect(mapStatusResponse(data)).toEqual({
+        status: 'warning',
+        message: '2 source(s) reconnecting: TCP, UDP',
+      });
+    });
+  });
+
+  describe('disconnected (error) — priority over everything else', () => {
+    it('returns error for a single disconnected source', () => {
+      const data = makeResponse([
+        makeSource('XML', 'disconnected'),
+        makeSource('TCP', 'connected'),
+      ]);
+      expect(mapStatusResponse(data)).toEqual({
+        status: 'error',
+        message: '1 source(s) disconnected: XML',
+      });
+    });
+
+    it('lists all disconnected source names', () => {
+      const data = makeResponse([
+        makeSource('XML', 'disconnected'),
+        makeSource('TCP', 'disconnected'),
+      ]);
+      expect(mapStatusResponse(data)).toEqual({
+        status: 'error',
+        message: '2 source(s) disconnected: XML, TCP',
+      });
+    });
+
+    it('wins over connecting: any disconnected source → error, not warning', () => {
+      // A mixed state (one hard-down + one reconnecting) is still a user-
+      // visible failure and should be red.
+      const data = makeResponse([
+        makeSource('XML', 'disconnected'),
+        makeSource('TCP', 'connecting'),
+      ]);
+      expect(mapStatusResponse(data)).toEqual({
+        status: 'error',
+        message: '1 source(s) disconnected: XML',
+      });
+    });
+  });
+
+  describe('malformed data', () => {
+    it('treats missing sources array as empty', () => {
+      const data = { event: { currentRaceId: null, raceName: null, onCourseCount: 0, resultsCount: 0 } } as unknown as MinimalStatusResponse;
+      expect(mapStatusResponse(data)).toEqual({
+        status: 'warning',
+        message: 'No data sources configured',
+      });
+    });
+
+    it('tolerates missing event object', () => {
+      const data = { sources: [makeSource('TCP', 'connected')] } as unknown as MinimalStatusResponse;
+      expect(mapStatusResponse(data)).toEqual({
+        status: 'ok',
+        message: 'C123 Server running',
+      });
+    });
+  });
+});

--- a/src/tray/statusMapping.ts
+++ b/src/tray/statusMapping.ts
@@ -1,0 +1,82 @@
+/**
+ * Map a /api/status response (or a fetch failure) to a TrayStatus + message.
+ *
+ * This is the status-mapping core of the standalone tray monitor, extracted
+ * as a pure function so it can be unit-tested without pulling in systray2.
+ *
+ * Priority (first match wins):
+ *   error   — fetch failed, or any source is terminally `disconnected`
+ *   warning — no sources configured, or any source is `connecting` (transient)
+ *   ok      — all sources are `connected`
+ *
+ * Rationale:
+ *   A permanently `disconnected` source (wrong XML path, dead TCP host) is a
+ *   red state that won't recover on its own, so the tray should be red — not
+ *   yellow "reconnecting". A `connecting` source, by contrast, is a normal
+ *   transient state during reconnect backoff and stays yellow. The previous
+ *   implementation conflated the two.
+ */
+
+import type { TrayStatus } from './icons.js';
+import type { ServerStatusResponse, SourceStatusInfo } from '../admin/types.js';
+
+export interface TrayStatusResult {
+  status: TrayStatus;
+  message: string;
+}
+
+/**
+ * Subset of ServerStatusResponse that the tray monitor actually needs.
+ * Using a subset (rather than the full type) keeps this function resilient
+ * to non-breaking schema additions on the server side.
+ */
+export type MinimalStatusResponse = Pick<ServerStatusResponse, 'sources' | 'event'>;
+
+/**
+ * Map a status response (or a fetch failure) to tray state.
+ *
+ * @param data         parsed `/api/status` body, or `null` if fetch failed
+ * @param fetchError   optional fetch error message — if set, always produces `error`
+ */
+export function mapStatusResponse(
+  data: MinimalStatusResponse | null,
+  fetchError?: string,
+): TrayStatusResult {
+  if (fetchError) {
+    return { status: 'error', message: fetchError };
+  }
+  if (!data) {
+    return { status: 'error', message: 'Server unreachable' };
+  }
+
+  const sources: SourceStatusInfo[] = data.sources ?? [];
+  const disconnected = sources.filter((s) => s.status === 'disconnected');
+  const connecting = sources.filter((s) => s.status === 'connecting');
+
+  // disconnected wins over everything else: a terminal failure is red.
+  if (disconnected.length > 0) {
+    const names = disconnected.map((s) => s.name).join(', ');
+    return {
+      status: 'error',
+      message: `${disconnected.length} source(s) disconnected: ${names}`,
+    };
+  }
+
+  if (sources.length === 0) {
+    return { status: 'warning', message: 'No data sources configured' };
+  }
+
+  if (connecting.length > 0) {
+    const names = connecting.map((s) => s.name).join(', ');
+    return {
+      status: 'warning',
+      message: `${connecting.length} source(s) reconnecting: ${names}`,
+    };
+  }
+
+  // All sources connected.
+  // `||` (not `??`) so an empty raceName string also falls through to the
+  // default — otherwise the status bar would show "Status: " with nothing.
+  const raceName = data.event?.raceName || 'C123 Server running';
+  return { status: 'ok', message: raceName };
+}


### PR DESCRIPTION
## Summary

Restores the tray icon UX for Windows installer deployments (#9) without touching the in-service TrayManager.

The installed Windows service runs in Session 0 and cannot show tray icons (architectural limit since Vista). This PR adds a separate user-session process — `c123-server tray` — that polls `/api/status` over HTTP every 3 s and drives the existing `TrayManager`. The installer ships a hidden-launcher `.vbs` and drops a `{userstartup}` shortcut so the tray auto-starts at login.

- **No changes** to the Server, UnifiedServer, or TrayManager.
- **No new module or test file** — logic is ~90 lines in `cli.ts`, the status mapping is a 5-line switch.
- **No `[Tasks]` opt-out UX** in the installer — one opinionated default shortcut, delete from `shell:startup` if not wanted.
- **No API extension** — reuses the existing `event.raceName` for the tooltip.

### Technical gotchas handled

| Gotcha | Fix |
|---|---|
| `node.exe` from a `.lnk` flashes a console window at login | `wscript.exe tray-launcher.vbs` wrapper, `sh.Run(…, 0, False)` |
| `fetch()` without a timeout hangs on filtered ports | `AbortController` with a 2 s timeout per poll |
| `setInterval` can stack slow polls | Recursive `setTimeout` pattern |
| `systray2` is an optional dependency | Already shipped by `npm ci --omit=dev` in `prepare-installer-payload.js`, confirmed by reading the script |
| `wscript.exe` discards stdout | Documented debug path: run `node.exe cli.js tray` manually from `cmd` |

### Files changed

- `src/cli.ts` — `tray` subcommand added (~90 lines)
- `installer/tray-launcher.vbs` — new, ~30 lines
- `installer/c123-server.iss` — one `[Files]` entry, one `[Icons]` entry
- `docs/DEPLOYMENT.md` — "System tray icon" section rewrite

### Behavior

- **Green** — server reachable, all data sources `connected`. Tooltip shows current `raceName` or "C123 Server running".
- **Yellow** — server reachable but at least one source not connected, or no sources configured. Tooltip names the reconnecting sources.
- **Red** — fetch failed (timeout, network error, non-2xx response). Tooltip "Server unreachable". Icon stays red until the server comes back — explicit Quit is the only exit path (no auto-exit on prolonged unreachable).
- **Menu** — Open Dashboard (unchanged), Quit (unchanged).

## Test plan

- [x] `npm run typecheck` — passes clean
- [x] `npm run lint` — only pre-existing warnings in unrelated files
- [x] `npm test` — 588 tests pass
- [x] `npm run build` — compiles
- [x] `node dist/cli.js --help` — lists new `tray` command + `--target-url`/`--poll-interval` options
- [x] `node dist/cli.js tray` — fails cleanly with exit 1 on Linux (no systray2), error logged
- [x] `node dist/cli.js tray --target-url http://localhost:9999 --poll-interval 5000` — arg parsing OK
- [ ] **Manual Windows test** — build installer via `npm run build:installer:local`, install on a Windows box, verify:
  - [ ] Login triggers the tray icon with no console window flash
  - [ ] Icon goes green when the service is up, red when `sc.exe stop c123server.exe`, green again on restart
  - [ ] Right-click → Open Dashboard opens `http://localhost:27123`
  - [ ] Right-click → Quit cleanly exits (no zombie node.exe in Task Manager)
  - [ ] Uninstall removes the Startup shortcut

Closes #69