### PR TITLE
feat: auto-transition live event status based on C123 race statuses

### DIFF
--- a/src/admin-ui/index.html
+++ b/src/admin-ui/index.html
@@ -182,6 +182,15 @@
         </div>
       </div>
 
+      <!-- Auto Status Toggle -->
+      <div class="live-auto-status-row">
+        <label class="live-channel-toggle">
+          <input type="checkbox" id="liveToggleAutoStatus" onchange="toggleAutoStatus()">
+          <span>Auto Status</span>
+        </label>
+        <span class="text-muted small">Automatically transitions event status based on race progress</span>
+      </div>
+
       <!-- Push Status Cards (per-channel) with integrated toggles -->
       <div class="live-channels-grid">
         <div class="live-channel-card" id="liveChannelXml">

--- a/src/admin-ui/main.js
+++ b/src/admin-ui/main.js
@@ -1229,6 +1229,10 @@ function renderLiveStatus(status) {
   if (toggleOnCourse) toggleOnCourse.checked = status.channels.oncourse.enabled;
   if (toggleResults) toggleResults.checked = status.channels.results.enabled;
 
+  // Update auto-status toggle
+  var toggleAutoStatus = document.getElementById('liveToggleAutoStatus');
+  if (toggleAutoStatus) toggleAutoStatus.checked = status.autoStatus;
+
   // Update pause button
   const pauseBtn = document.getElementById('livePauseBtn');
   const pauseBtnText = document.getElementById('livePauseBtnText');
@@ -1904,6 +1908,35 @@ async function toggleLiveChannel(channel) {
     showToast('Channel ' + (enabled ? 'enabled' : 'disabled'), 'success');
   } catch (error) {
     showToast('Failed to update channel: ' + error.message, 'error');
+    checkbox.checked = !enabled; // Revert
+  }
+}
+
+/**
+ * Toggle auto-status
+ */
+async function toggleAutoStatus() {
+  const checkbox = document.getElementById('liveToggleAutoStatus');
+  if (!checkbox) return;
+
+  const enabled = checkbox.checked;
+
+  try {
+    const res = await fetch('/api/live/config', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ autoStatus: enabled })
+    });
+
+    const data = await res.json();
+
+    if (!res.ok) {
+      throw new Error(data.error || 'Failed to update config');
+    }
+
+    showToast('Auto-status ' + (enabled ? 'enabled' : 'disabled'), 'success');
+  } catch (error) {
+    showToast('Failed to update auto-status: ' + error.message, 'error');
     checkbox.checked = !enabled; // Revert
   }
 }

--- a/src/admin-ui/styles.css
+++ b/src/admin-ui/styles.css
@@ -2602,6 +2602,21 @@ fieldset.modal-section > legend {
   font-size: var(--text-sm);
 }
 
+.live-auto-status-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  margin-bottom: var(--space-3);
+  padding: var(--space-2) var(--space-3);
+  background: var(--bg-body);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+}
+
+.live-auto-status-row .live-channel-toggle {
+  margin-left: 0;
+}
+
 .live-channels-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -258,5 +258,6 @@ export const DEFAULT_APP_SETTINGS: AppSettings = {
     pushXml: true,
     pushOnCourse: true,
     pushResults: true,
+    autoStatus: true,
   },
 };

--- a/src/live/LivePusher.ts
+++ b/src/live/LivePusher.ts
@@ -97,6 +97,7 @@ export class LivePusher extends EventEmitter<LivePusherEvents> {
   // Auto-status
   private autoStatusEnabled = false;
   private previousRaceStatuses: Map<string, number> = new Map();
+  private isTransitioning = false;
 
   constructor(xmlDataService: XmlDataService) {
     super();
@@ -155,20 +156,20 @@ export class LivePusher extends EventEmitter<LivePusherEvents> {
       Logger.warn('LivePusher', 'Failed to refresh participant mapping', error);
     }
 
-    // Setup event listeners
-    this.setupEventListeners();
-
     // Initial push of current state (in case state arrived before connect)
     const currentState = eventState.state;
     if (config.pushResults && currentState.results) {
       this.scheduleResultsPush(currentState.results);
     }
 
-    // Auto-status: evaluate current schedule state (catch-up on reconnect)
+    // Auto-status: init baseline BEFORE listeners to avoid false change detection
     if (this.autoStatusEnabled && currentState.schedule.length > 0) {
       this.initRaceStatuses(currentState.schedule);
       this.evaluateAutoStatus();
     }
+
+    // Setup event listeners (after init so race status baseline is set)
+    this.setupEventListeners();
 
     // Reset circuit breaker
     this.consecutiveFailures = 0;
@@ -754,6 +755,7 @@ export class LivePusher extends EventEmitter<LivePusherEvents> {
    * Only transitions forward (never backwards).
    */
   private async evaluateAutoStatus(): Promise<void> {
+    if (this.isTransitioning) return;
     if (!this.eventState || !this.client) return;
     if (this.status.state !== 'connected') return;
 
@@ -765,12 +767,15 @@ export class LivePusher extends EventEmitter<LivePusherEvents> {
     if (!isForwardTransition(current, desired)) return;
 
     Logger.info('LivePusher', `Auto-status: transitioning ${current} → ${desired}`);
+    this.isTransitioning = true;
     try {
       await this.transitionStatus(desired);
     } catch (error) {
       // Clear cached statuses so the next state update re-triggers evaluation
       this.previousRaceStatuses.clear();
       Logger.warn('LivePusher', 'Auto-status: transition failed, will retry on next change', error);
+    } finally {
+      this.isTransitioning = false;
     }
   }
 

--- a/src/live/LivePusher.ts
+++ b/src/live/LivePusher.ts
@@ -12,9 +12,10 @@ import type { XmlDataService } from '../service/XmlDataService.js';
 import type { EventState } from '../state/EventState.js';
 import type { XmlChangeNotifier } from '../xml/XmlChangeNotifier.js';
 import type { EventStateData } from '../state/types.js';
-import type { XmlSection } from '../protocol/types.js';
+import type { XmlSection, ScheduleRace } from '../protocol/types.js';
 import { LiveClient } from './LiveClient.js';
 import { LiveTransformer } from './LiveTransformer.js';
+import { deriveEventStatus, isForwardTransition } from './deriveEventStatus.js';
 import type {
   LiveStatus,
   ChannelStatus,
@@ -43,6 +44,7 @@ export interface LivePusherConfig {
   pushXml: boolean;
   pushOnCourse: boolean;
   pushResults: boolean;
+  autoStatus: boolean;
 }
 
 /**
@@ -92,6 +94,10 @@ export class LivePusher extends EventEmitter<LivePusherEvents> {
   private xmlChangeListener: ((sections: XmlSection[]) => void) | null = null;
   private eventStateListener: ((state: EventStateData) => void) | null = null;
 
+  // Auto-status
+  private autoStatusEnabled = false;
+  private previousRaceStatuses: Map<string, number> = new Map();
+
   constructor(xmlDataService: XmlDataService) {
     super();
     this.xmlDataService = xmlDataService;
@@ -132,6 +138,11 @@ export class LivePusher extends EventEmitter<LivePusherEvents> {
     this.status.channels.oncourse.enabled = config.pushOnCourse;
     this.status.channels.results.enabled = config.pushResults;
 
+    // Auto-status
+    this.autoStatusEnabled = config.autoStatus;
+    this.status.autoStatus = config.autoStatus;
+    this.previousRaceStatuses.clear();
+
     // Store references
     this.xmlChangeNotifier = xmlChangeNotifier;
     this.eventState = eventState;
@@ -151,6 +162,12 @@ export class LivePusher extends EventEmitter<LivePusherEvents> {
     const currentState = eventState.state;
     if (config.pushResults && currentState.results) {
       this.scheduleResultsPush(currentState.results);
+    }
+
+    // Auto-status: evaluate current schedule state (catch-up on reconnect)
+    if (this.autoStatusEnabled && currentState.schedule.length > 0) {
+      this.initRaceStatuses(currentState.schedule);
+      this.evaluateAutoStatus();
     }
 
     // Reset circuit breaker
@@ -201,6 +218,9 @@ export class LivePusher extends EventEmitter<LivePusherEvents> {
     // Clear buffers
     this.onCourseLastPush = null;
     this.pendingOnCourse = null;
+
+    // Clear auto-status state
+    this.previousRaceStatuses.clear();
 
     // Clear references
     this.client = null;
@@ -306,6 +326,23 @@ export class LivePusher extends EventEmitter<LivePusherEvents> {
   }
 
   /**
+   * Update auto-status toggle
+   */
+  updateAutoStatus(enabled: boolean): void {
+    this.autoStatusEnabled = enabled;
+    this.status.autoStatus = enabled;
+
+    if (enabled && this.eventState) {
+      // Re-evaluate immediately when toggled on
+      this.initRaceStatuses(this.eventState.state.schedule);
+      this.evaluateAutoStatus();
+    }
+
+    Logger.info('LivePusher', `Auto-status ${enabled ? 'enabled' : 'disabled'}`);
+    this.emitStatusChange();
+  }
+
+  /**
    * Get current status
    */
   getStatus(): LiveStatus {
@@ -391,6 +428,11 @@ export class LivePusher extends EventEmitter<LivePusherEvents> {
     // Handle Results push (debounce 1s per raceId)
     if (this.status.channels.results.enabled && state.results) {
       this.scheduleResultsPush(state.results);
+    }
+
+    // Auto-status: check for race status changes in schedule
+    if (this.autoStatusEnabled && this.haveRaceStatusesChanged(state.schedule)) {
+      this.evaluateAutoStatus();
     }
   }
 
@@ -672,6 +714,65 @@ export class LivePusher extends EventEmitter<LivePusherEvents> {
   }
 
   /**
+   * Initialize race status map without triggering evaluation.
+   * Used on connect to set baseline before first change detection.
+   */
+  private initRaceStatuses(races: ScheduleRace[]): void {
+    this.previousRaceStatuses.clear();
+    for (const race of races) {
+      this.previousRaceStatuses.set(race.raceId, race.raceStatus);
+    }
+  }
+
+  /**
+   * Check if any race status has changed since last check.
+   * Updates the stored map and returns true if a change was detected.
+   */
+  private haveRaceStatusesChanged(races: ScheduleRace[]): boolean {
+    let changed = false;
+    const newMap = new Map<string, number>();
+
+    for (const race of races) {
+      newMap.set(race.raceId, race.raceStatus);
+      const prev = this.previousRaceStatuses.get(race.raceId);
+      if (prev !== race.raceStatus) {
+        changed = true;
+      }
+    }
+
+    // Also detect if race set changed (new/removed races)
+    if (newMap.size !== this.previousRaceStatuses.size) {
+      changed = true;
+    }
+
+    this.previousRaceStatuses = newMap;
+    return changed;
+  }
+
+  /**
+   * Evaluate current schedule and auto-transition if needed.
+   * Only transitions forward (never backwards).
+   */
+  private async evaluateAutoStatus(): Promise<void> {
+    if (!this.eventState || !this.client) return;
+    if (this.status.state !== 'connected') return;
+
+    const desired = deriveEventStatus(this.eventState.state.schedule);
+    if (!desired) return;
+
+    const current = this.status.eventStatus;
+    if (!current) return;
+    if (!isForwardTransition(current, desired)) return;
+
+    Logger.info('LivePusher', `Auto-status: transitioning ${current} → ${desired}`);
+    try {
+      await this.transitionStatus(desired);
+    } catch (error) {
+      Logger.warn('LivePusher', 'Auto-status: transition failed', error);
+    }
+  }
+
+  /**
    * Create initial status
    */
   private createInitialStatus(): LiveStatus {
@@ -701,6 +802,7 @@ export class LivePusher extends EventEmitter<LivePusherEvents> {
       },
       lastError: null,
       connectedAt: null,
+      autoStatus: false,
     };
   }
 }

--- a/src/live/LivePusher.ts
+++ b/src/live/LivePusher.ts
@@ -768,7 +768,9 @@ export class LivePusher extends EventEmitter<LivePusherEvents> {
     try {
       await this.transitionStatus(desired);
     } catch (error) {
-      Logger.warn('LivePusher', 'Auto-status: transition failed', error);
+      // Clear cached statuses so the next state update re-triggers evaluation
+      this.previousRaceStatuses.clear();
+      Logger.warn('LivePusher', 'Auto-status: transition failed, will retry on next change', error);
     }
   }
 

--- a/src/live/__tests__/deriveEventStatus.test.ts
+++ b/src/live/__tests__/deriveEventStatus.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Tests for deriveEventStatus
+ */
+
+import { describe, it, expect } from 'vitest';
+import { deriveEventStatus, isForwardTransition, STATUS_ORDER } from '../deriveEventStatus.js';
+import type { ScheduleRace } from '../../protocol/types.js';
+
+/** Helper to create a minimal ScheduleRace with a given status */
+function race(raceId: string, raceStatus: number): ScheduleRace {
+  return {
+    order: 1,
+    raceId,
+    race: raceId,
+    mainTitle: raceId,
+    subTitle: '',
+    shortTitle: raceId,
+    raceStatus,
+    startTime: '10:00:00',
+  };
+}
+
+describe('deriveEventStatus', () => {
+  it('returns null for empty schedule', () => {
+    expect(deriveEventStatus([])).toBeNull();
+  });
+
+  it('returns null when all races are excluded (Cancelled/Rescheduled/Postponed)', () => {
+    expect(deriveEventStatus([
+      race('r1', 7),  // Cancelled
+      race('r2', 12), // Rescheduled
+      race('r3', 13), // Postponed
+    ])).toBeNull();
+  });
+
+  it('returns draft when all races are Scheduled (0)', () => {
+    expect(deriveEventStatus([
+      race('r1', 0),
+      race('r2', 0),
+    ])).toBe('draft');
+  });
+
+  it('returns startlist when at least one race is StartList (1)', () => {
+    expect(deriveEventStatus([
+      race('r1', 0),
+      race('r2', 1),
+    ])).toBe('startlist');
+  });
+
+  it('returns startlist for Delayed (2) races', () => {
+    expect(deriveEventStatus([
+      race('r1', 0),
+      race('r2', 2),
+    ])).toBe('startlist');
+  });
+
+  it('returns startlist for GettingReady (8) races', () => {
+    expect(deriveEventStatus([
+      race('r1', 8),
+    ])).toBe('startlist');
+  });
+
+  it('returns running when at least one race is InProgress (3)', () => {
+    expect(deriveEventStatus([
+      race('r1', 1),
+      race('r2', 3),
+      race('r3', 0),
+    ])).toBe('running');
+  });
+
+  it('returns running when at least one race is Unofficial (4)', () => {
+    expect(deriveEventStatus([
+      race('r1', 5),
+      race('r2', 4),
+    ])).toBe('running');
+  });
+
+  it('returns running for mix of InProgress and Official', () => {
+    expect(deriveEventStatus([
+      race('r1', 5),
+      race('r2', 3),
+      race('r3', 5),
+    ])).toBe('running');
+  });
+
+  it('returns official when all active races are Official (5)', () => {
+    expect(deriveEventStatus([
+      race('r1', 5),
+      race('r2', 5),
+    ])).toBe('official');
+  });
+
+  it('returns official for mix of Official (5) and Revised (6)', () => {
+    expect(deriveEventStatus([
+      race('r1', 5),
+      race('r2', 6),
+    ])).toBe('official');
+  });
+
+  it('excludes Cancelled races from "all official" check', () => {
+    expect(deriveEventStatus([
+      race('r1', 5),
+      race('r2', 7),  // Cancelled — excluded
+      race('r3', 5),
+    ])).toBe('official');
+  });
+
+  it('excludes Postponed races from evaluation', () => {
+    expect(deriveEventStatus([
+      race('r1', 3),
+      race('r2', 13), // Postponed — excluded
+    ])).toBe('running');
+  });
+
+  it('treats Unconfirmed (9) as startlist-level', () => {
+    expect(deriveEventStatus([
+      race('r1', 9),
+    ])).toBe('startlist');
+  });
+
+  it('treats Protested (10) as startlist-level', () => {
+    expect(deriveEventStatus([
+      race('r1', 10),
+    ])).toBe('startlist');
+  });
+
+  it('treats Interrupted (11) as startlist-level', () => {
+    expect(deriveEventStatus([
+      race('r1', 11),
+    ])).toBe('startlist');
+  });
+});
+
+describe('isForwardTransition', () => {
+  it('returns true for draft → startlist', () => {
+    expect(isForwardTransition('draft', 'startlist')).toBe(true);
+  });
+
+  it('returns true for startlist → running', () => {
+    expect(isForwardTransition('startlist', 'running')).toBe(true);
+  });
+
+  it('returns true for running → official', () => {
+    expect(isForwardTransition('running', 'official')).toBe(true);
+  });
+
+  it('returns true for running → finished', () => {
+    expect(isForwardTransition('running', 'finished')).toBe(true);
+  });
+
+  it('returns true for finished → official', () => {
+    expect(isForwardTransition('finished', 'official')).toBe(true);
+  });
+
+  it('returns false for same status', () => {
+    expect(isForwardTransition('running', 'running')).toBe(false);
+  });
+
+  it('returns false for backward transition official → running', () => {
+    expect(isForwardTransition('official', 'running')).toBe(false);
+  });
+
+  it('returns false for backward transition running → draft', () => {
+    expect(isForwardTransition('running', 'draft')).toBe(false);
+  });
+});
+
+describe('STATUS_ORDER', () => {
+  it('has correct ordering', () => {
+    expect(STATUS_ORDER.draft).toBeLessThan(STATUS_ORDER.startlist);
+    expect(STATUS_ORDER.startlist).toBeLessThan(STATUS_ORDER.running);
+    expect(STATUS_ORDER.running).toBeLessThan(STATUS_ORDER.finished);
+    expect(STATUS_ORDER.finished).toBeLessThan(STATUS_ORDER.official);
+  });
+});

--- a/src/live/deriveEventStatus.ts
+++ b/src/live/deriveEventStatus.ts
@@ -1,0 +1,71 @@
+/**
+ * Derive Event Status from C123 Race Statuses
+ *
+ * Pure function that maps per-race C123 RaceStatus values
+ * to a single live EventStatus for the whole event.
+ */
+
+import type { ScheduleRace } from '../protocol/types.js';
+import type { EventStatus } from './types.js';
+
+/**
+ * Ordering of EventStatus for forward-only transitions.
+ */
+export const STATUS_ORDER: Record<EventStatus, number> = {
+  draft: 0,
+  startlist: 1,
+  running: 2,
+  finished: 3,
+  official: 4,
+};
+
+/**
+ * C123 RaceStatus values that are excluded from evaluation.
+ * These races don't block transitions (e.g., a cancelled race
+ * shouldn't prevent the event from becoming "official").
+ */
+const EXCLUDED_RACE_STATUSES = new Set([
+  7,  // Cancelled
+  12, // Rescheduled
+  13, // Postponed
+]);
+
+/**
+ * Derive the desired EventStatus from current race statuses.
+ *
+ * Priority (highest first):
+ * 1. Any InProgress(3) or Unofficial(4) → running
+ * 2. All Official(5) or Revised(6) → official
+ * 3. Any status >= 1 (StartList, Delayed, GettingReady, etc.) → startlist
+ * 4. All Scheduled(0) → draft
+ *
+ * Returns null if schedule is empty or all races are excluded.
+ */
+export function deriveEventStatus(races: ScheduleRace[]): EventStatus | null {
+  if (races.length === 0) return null;
+
+  const active = races.filter(r => !EXCLUDED_RACE_STATUSES.has(r.raceStatus));
+  if (active.length === 0) return null;
+
+  const statuses = active.map(r => r.raceStatus);
+
+  // Any race in progress or with unofficial results → event is running
+  if (statuses.some(s => s === 3 || s === 4)) return 'running';
+
+  // All races official or revised → event is official
+  if (statuses.every(s => s === 5 || s === 6)) return 'official';
+
+  // Any race beyond Scheduled (StartList, Delayed, GettingReady, etc.)
+  if (statuses.some(s => s >= 1)) return 'startlist';
+
+  // All Scheduled
+  return 'draft';
+}
+
+/**
+ * Check if transitioning from current to next is a forward move.
+ * Returns false for same status or backward transitions.
+ */
+export function isForwardTransition(current: EventStatus, next: EventStatus): boolean {
+  return STATUS_ORDER[next] > STATUS_ORDER[current];
+}

--- a/src/live/types.ts
+++ b/src/live/types.ts
@@ -210,6 +210,8 @@ export interface LiveConfig {
   pushOnCourse: boolean;
   /** Push Results data */
   pushResults: boolean;
+  /** Automatically transition event status based on C123 race statuses */
+  autoStatus: boolean;
 }
 
 /**
@@ -224,6 +226,7 @@ export const DEFAULT_LIVE_CONFIG: LiveConfig = {
   pushXml: true,
   pushOnCourse: true,
   pushResults: true,
+  autoStatus: true,
 };
 
 // ============================================================================
@@ -289,4 +292,6 @@ export interface LiveStatus {
   lastError: string | null;
   /** Connected timestamp */
   connectedAt: string | null;
+  /** Auto-status enabled */
+  autoStatus: boolean;
 }

--- a/src/unified/UnifiedServer.ts
+++ b/src/unified/UnifiedServer.ts
@@ -193,6 +193,7 @@ export class UnifiedServer extends EventEmitter<UnifiedServerEvents> {
           pushXml: config.pushXml,
           pushOnCourse: config.pushOnCourse,
           pushResults: config.pushResults,
+          autoStatus: config.autoStatus ?? true,
         },
         xmlChangeNotifier,
         eventState,
@@ -2819,6 +2820,7 @@ export class UnifiedServer extends EventEmitter<UnifiedServerEvents> {
           pushXml: liveConfig.pushXml,
           pushOnCourse: liveConfig.pushOnCourse,
           pushResults: liveConfig.pushResults,
+          autoStatus: liveConfig.autoStatus ?? true,
         },
         xmlChangeNotifier,
         eventState,
@@ -2939,6 +2941,7 @@ export class UnifiedServer extends EventEmitter<UnifiedServerEvents> {
           pushXml: liveConfig.pushXml,
           pushOnCourse: liveConfig.pushOnCourse,
           pushResults: liveConfig.pushResults,
+          autoStatus: liveConfig.autoStatus ?? true,
         },
         xmlChangeNotifier,
         eventState,
@@ -3138,9 +3141,9 @@ export class UnifiedServer extends EventEmitter<UnifiedServerEvents> {
   }
 
   /**
-   * PATCH /api/live/config - Update push channel configuration
+   * PATCH /api/live/config - Update push channel and auto-status configuration
    *
-   * Body: { pushXml?: boolean, pushOnCourse?: boolean, pushResults?: boolean }
+   * Body: { pushXml?: boolean, pushOnCourse?: boolean, pushResults?: boolean, autoStatus?: boolean }
    */
   private handleLiveConfig(req: Request, res: Response): void {
     if (!this.livePusher) {
@@ -3148,11 +3151,11 @@ export class UnifiedServer extends EventEmitter<UnifiedServerEvents> {
       return;
     }
 
-    const { pushXml, pushOnCourse, pushResults } = req.body;
+    const { pushXml, pushOnCourse, pushResults, autoStatus } = req.body;
 
     // Validate that at least one field is provided
-    if (pushXml === undefined && pushOnCourse === undefined && pushResults === undefined) {
-      res.status(400).json({ error: 'At least one channel must be specified' });
+    if (pushXml === undefined && pushOnCourse === undefined && pushResults === undefined && autoStatus === undefined) {
+      res.status(400).json({ error: 'At least one field must be specified' });
       return;
     }
 
@@ -3169,16 +3172,29 @@ export class UnifiedServer extends EventEmitter<UnifiedServerEvents> {
       res.status(400).json({ error: 'pushResults must be a boolean' });
       return;
     }
+    if (autoStatus !== undefined && typeof autoStatus !== 'boolean') {
+      res.status(400).json({ error: 'autoStatus must be a boolean' });
+      return;
+    }
 
     try {
-      // Update pusher
-      this.livePusher.updateChannels({ pushXml, pushOnCourse, pushResults });
+      // Update channel config
+      if (pushXml !== undefined || pushOnCourse !== undefined || pushResults !== undefined) {
+        this.livePusher.updateChannels({ pushXml, pushOnCourse, pushResults });
 
-      // Save to settings
-      const settings = getAppSettings();
-      settings.setLiveChannels({ pushXml, pushOnCourse, pushResults });
+        const settings = getAppSettings();
+        settings.setLiveChannels({ pushXml, pushOnCourse, pushResults });
+      }
 
-      Logger.info('Unified', `Live-Mini channels updated: ${JSON.stringify({ pushXml, pushOnCourse, pushResults })}`);
+      // Update auto-status
+      if (autoStatus !== undefined) {
+        this.livePusher.updateAutoStatus(autoStatus);
+
+        const settings = getAppSettings();
+        settings.updateLiveConfig({ autoStatus });
+      }
+
+      Logger.info('Unified', `Live-Mini config updated: ${JSON.stringify({ pushXml, pushOnCourse, pushResults, autoStatus })}`);
 
       const status = this.livePusher.getStatus();
       this.broadcastLiveStatus(status);
@@ -3190,6 +3206,7 @@ export class UnifiedServer extends EventEmitter<UnifiedServerEvents> {
           oncourse: status.channels.oncourse.enabled,
           results: status.channels.results.enabled,
         },
+        autoStatus: status.autoStatus,
         status,
       });
     } catch (err) {


### PR DESCRIPTION
Closes #65

## Summary

- Add **Auto Status** toggle (default ON) that automatically transitions live event lifecycle based on C123 race statuses from Schedule messages
- Pure mapping function: Scheduled→draft, StartList→startlist, InProgress/Unofficial→running, all Official→official
- Forward-only transitions — status never goes backwards
- Cancelled/Rescheduled/Postponed races excluded from evaluation
- Toggle available in Admin UI live panel, persisted in settings

## Changes

| File | Change |
|------|--------|
| `src/live/deriveEventStatus.ts` | **New** — pure mapping function + forward-only check |
| `src/live/__tests__/deriveEventStatus.test.ts` | **New** — 25 unit tests |
| `src/live/types.ts` | Add `autoStatus` to `LiveConfig` and `LiveStatus` |
| `src/config/types.ts` | Add `autoStatus: true` to default settings |
| `src/live/LivePusher.ts` | Core auto-status logic: change detection, evaluation, toggle |
| `src/unified/UnifiedServer.ts` | Extend `PATCH /api/live/config` for `autoStatus`, pass in connect/reconnect |
| `src/admin-ui/index.html` | Auto Status checkbox toggle |
| `src/admin-ui/styles.css` | Styling for auto-status row |
| `src/admin-ui/main.js` | `toggleAutoStatus()` handler + sync |

## Test plan

- [x] `npm run build` — compiles clean
- [x] `npm test` — 618/618 tests pass (25 new)
- [ ] Manual test with replay: verify auto-transitions in log
- [ ] Verify toggle ON/OFF persists across restart
- [ ] Verify forward-only: manual set to official → auto-status stays

🤖 Generated with [Claude Code](https://claude.com/claude-code)