### PR TITLE
fix: preserve fixed-width gates string (trimValues)

### DIFF
--- a/src/protocol/__tests__/xml-parser.test.ts
+++ b/src/protocol/__tests__/xml-parser.test.ts
@@ -257,6 +257,92 @@ describe('parseXmlMessage', () => {
     expect(results).toHaveLength(1);
     expect(results[0].type).toBe('unknown');
   });
+
+  it('preserves OnCourse gates with trailing commas (issue #75)', () => {
+    // OnCourse uses comma-separated format from Result Type="C"
+    // Trailing commas represent unscored gates and must not be trimmed
+    const xml =
+      '<Canoe123 System="Main">' +
+      '<OnCourse Total="1" Position="1">' +
+      '<Participant Bib="42" Name="TEST" Club="" Nat="" Race="" RaceId="TEST" Warning="" />' +
+      '<Result Type="C" Gates="0,0,0,2,,,,,,,,,,,,,,,,,,,,,,,,,,," Completed="N" dtStart="10:00:00.000" />' +
+      '<Result Type="T" Pen="6" Time="5000" Rank="1" />' +
+      '</OnCourse>' +
+      '</Canoe123>';
+
+    const results = parseXmlMessage(xml);
+    const data = results[0].data;
+    expect(data).not.toBeNull();
+    if (data && 'competitors' in data) {
+      const comp = data.competitors[0];
+      expect(comp.pen).toBe(6);
+      // Comma-separated gates must preserve trailing commas (unscored gates)
+      expect(comp.gates).toBe('0,0,0,2,,,,,,,,,,,,,,,,,,,,,,,,,,,');
+      expect(comp.gates.endsWith(',')).toBe(true);
+    }
+  });
+
+  it('preserves fixed-width Results gates with sparse scoring (issue #75)', () => {
+    // Gate 5 = touch (2), rest unscored
+    // Fixed-width: 3 chars per gate, right-aligned, spaces = unscored
+    // Build a precise 90-char gates string (30 gates × 3 chars)
+    const gateBlocks = Array.from({ length: 30 }, (_, i) => (i === 4 ? '  2' : '   '));
+    const sparseGates = gateBlocks.join('');
+    expect(sparseGates.length).toBe(90); // sanity check
+
+    const xml =
+      '<Canoe123 System="Main">' +
+      '<Results RaceId="TEST" Current="Y" MainTitle="Test" SubTitle="">' +
+      '<Row Number="1">' +
+      '<Participant Bib="42" Name="TEST" GivenName="T" FamilyName="TEST" Club="" StartOrder="1" StartTime="" />' +
+      `<Result Type="T" Pen="2" Gates="${sparseGates}" Time="80.00" Total="82.00" Rank="1" Behind="" />` +
+      '</Row>' +
+      '</Results>' +
+      '</Canoe123>';
+
+    const results = parseXmlMessage(xml);
+    const data = results[0].data;
+    expect(data).not.toBeNull();
+    if (data && 'rows' in data) {
+      const row = data.rows[0];
+
+      // Gates must preserve the full fixed-width string
+      expect(row.gates).toBe(sparseGates);
+      expect(row.gates.length).toBe(90);
+
+      // Verify gate 5 position (chars 12-14, 0-indexed)
+      const gate5 = row.gates.substring(12, 15);
+      expect(gate5.trim()).toBe('2');
+
+      // Verify gates 1-4 are unscored (spaces)
+      const gate1 = row.gates.substring(0, 3);
+      expect(gate1.trim()).toBe('');
+
+      // Fixed-width detection: must contain double-spaces
+      expect(row.gates.includes('  ')).toBe(true);
+    }
+  });
+
+  it('preserves fully-scored gates without trimming (issue #75)', () => {
+    const fullGates = '  0  0  0  0  2  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  2';
+    const xml =
+      '<Canoe123 System="Main">' +
+      '<Results RaceId="TEST" Current="Y" MainTitle="Test" SubTitle="">' +
+      '<Row Number="1">' +
+      '<Participant Bib="1" Name="TEST" GivenName="T" FamilyName="TEST" Club="" StartOrder="1" StartTime="" />' +
+      `<Result Type="T" Pen="4" Gates="${fullGates}" Time="80.00" Total="84.00" Rank="1" Behind="" />` +
+      '</Row>' +
+      '</Results>' +
+      '</Canoe123>';
+
+    const results = parseXmlMessage(xml);
+    const data = results[0].data;
+    if (data && 'rows' in data) {
+      // Full gates string must include leading spaces for fixed-width detection
+      expect(data.rows[0].gates).toBe(fullGates);
+      expect(data.rows[0].gates.includes('  ')).toBe(true);
+    }
+  });
 });
 
 describe('parseOnCourse', () => {

--- a/src/protocol/xml-parser.ts
+++ b/src/protocol/xml-parser.ts
@@ -16,7 +16,7 @@ const parser = new XMLParser({
   attributeNamePrefix: '@_',
   textNodeName: '#text',
   parseAttributeValue: false,
-  trimValues: true,
+  trimValues: false,
 });
 
 /**

--- a/src/service/XmlDataService.ts
+++ b/src/service/XmlDataService.ts
@@ -171,7 +171,7 @@ export class XmlDataService {
       attributeNamePrefix: '@_',
       allowBooleanAttributes: true,
       parseTagValue: true,
-      trimValues: true,
+      trimValues: false,
     });
   }
 

--- a/src/xml/XmlChangeNotifier.ts
+++ b/src/xml/XmlChangeNotifier.ts
@@ -73,7 +73,7 @@ export class XmlChangeNotifier extends EventEmitter<XmlChangeNotifierEvents> {
       attributeNamePrefix: '@_',
       allowBooleanAttributes: true,
       parseTagValue: false, // Keep as strings for consistent hashing
-      trimValues: true,
+      trimValues: false,
     });
   }
 


### PR DESCRIPTION
## Summary
- Set `trimValues: false` in all three `XMLParser` instances to preserve positional whitespace in fixed-width Gates attribute
- Fixes wrong gate position display in c123-penalty-check when gates are sparsely scored
- Added 3 tests covering sparse, fully-scored, and comma-separated gates formats

## Impact analysis
| Consumer | Format | Impact |
|----------|--------|--------|
| c123-scoreboard | both | Safe — regex split handles any whitespace |
| c123-penalty-check | Results (space) | **FIX** — fixed-width detection works again |
| LiveTransformer | OnCourse (comma) | Safe/better — trailing commas preserved |
| Admin UI | — | N/A |

## Test plan
- [x] All 621 tests pass (618 existing + 3 new)
- [x] Verified with c123-penalty-check — penalties display at correct gate positions
- [x] Second opinion review (Gemini + Claude Sonnet) — no blocking concerns

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)