### PR TITLE
fix: pair BR1/BR2 merged results by version (#81)

### DIFF
--- a/src/admin/AdminServer.ts
+++ b/src/admin/AdminServer.ts
@@ -722,7 +722,7 @@ export class AdminServer {
           return;
         }
 
-        const results = await this.xmlDataService.getMergedResults(race.classId);
+        const results = await this.xmlDataService.getMergedResults(id);
         res.json({ results, merged: true, classId: race.classId });
         return;
       }

--- a/src/service/XmlDataService.ts
+++ b/src/service/XmlDataService.ts
@@ -471,6 +471,9 @@ export class XmlDataService {
     const participants = this.getParticipantsFromCache();
 
     // RaceId format: {CLASS}[_{COURSE}]_BR{1|2}_{VERSION}
+    // Note: if raceId doesn't contain _BR1_ or _BR2_, the replace is a no-op
+    // and both variables will equal the original raceId, returning empty results.
+    // This is intentional — merged results only make sense for BR disciplines.
     const br1RaceId = raceId.replace(/_BR[12]_/, '_BR1_');
     const br2RaceId = raceId.replace(/_BR[12]_/, '_BR2_');
 

--- a/src/service/XmlDataService.ts
+++ b/src/service/XmlDataService.ts
@@ -455,20 +455,27 @@ export class XmlDataService {
   }
 
   /**
-   * Get merged results for both runs of a class
+   * Get merged results for both runs of a Best Run pair.
+   *
+   * Accepts any raceId belonging to the pair (BR1 or BR2) and derives
+   * the sibling raceId by swapping the run suffix. The version/day
+   * component is preserved, so when the XML contains multiple versions
+   * of the same class (e.g. a multi-day event), the matching pair is
+   * returned instead of the first one the schedule happened to list.
+   *
+   * @param raceId - Any raceId from the pair, e.g. "K1M_BR2_19".
    */
-  async getMergedResults(classId: string): Promise<XmlMergedResult[]> {
+  async getMergedResults(raceId: string): Promise<XmlMergedResult[]> {
     await this.loadIfNeeded();
-    const schedule = this.getScheduleFromCache();
     const results = this.getResultsFromCache();
     const participants = this.getParticipantsFromCache();
 
-    // Find BR1 and BR2 races for this class
-    const br1Race = schedule.find((s) => s.classId === classId && s.disId === 'BR1');
-    const br2Race = schedule.find((s) => s.classId === classId && s.disId === 'BR2');
+    // RaceId format: {CLASS}[_{COURSE}]_BR{1|2}_{VERSION}
+    const br1RaceId = raceId.replace(/_BR[12]_/, '_BR1_');
+    const br2RaceId = raceId.replace(/_BR[12]_/, '_BR2_');
 
-    const br1Results = br1Race ? results.get(br1Race.raceId) ?? [] : [];
-    const br2Results = br2Race ? results.get(br2Race.raceId) ?? [] : [];
+    const br1Results = results.get(br1RaceId) ?? [];
+    const br2Results = results.get(br2RaceId) ?? [];
 
     // Build participant map
     const participantMap = new Map(participants.map((p) => [p.id, p]));

--- a/src/service/__tests__/XmlDataService.test.ts
+++ b/src/service/__tests__/XmlDataService.test.ts
@@ -519,7 +519,7 @@ describe('XmlDataService', () => {
       await fsPromises.writeFile(xmlPath, xmlWithBothRuns);
       service.setPath(xmlPath);
 
-      const merged = await service.getMergedResults('K1M_ST');
+      const merged = await service.getMergedResults('K1M_ST_BR2_6');
 
       expect(merged).toHaveLength(2);
 
@@ -571,7 +571,7 @@ describe('XmlDataService', () => {
       await fsPromises.writeFile(xmlPath, xmlOneRun);
       service.setPath(xmlPath);
 
-      const merged = await service.getMergedResults('K1M_ST');
+      const merged = await service.getMergedResults('K1M_ST_BR1_6');
 
       expect(merged).toHaveLength(1);
       expect(merged[0].run1?.total).toBe(80000);
@@ -580,11 +580,95 @@ describe('XmlDataService', () => {
       expect(merged[0].bestRank).toBe(1);
     });
 
-    it('returns empty array for non-existent class', async () => {
+    it('returns empty array for non-existent race', async () => {
       service.setPath(xmlPath);
-      const merged = await service.getMergedResults('NONEXISTENT');
+      const merged = await service.getMergedResults('NONEXISTENT_BR1_1');
 
       expect(merged).toHaveLength(0);
+    });
+
+    it('pairs runs by version when multiple versions of the same class exist', async () => {
+      // Regression test for #81: with a two-day event, merged must use the
+      // BR1/BR2 pair from the same version (_19) instead of the first match (_18).
+      const xmlTwoDays = `<?xml version="1.0"?>
+<Canoe123Data>
+  <Participants>
+    <Id>12054.K1M_ST</Id>
+    <ClassId>K1M_ST</ClassId>
+    <EventBib>1</EventBib>
+    <FamilyName>PRSKAVEC</FamilyName>
+    <GivenName>Jiří</GivenName>
+    <Club>USK Praha</Club>
+    <IsTeam>false</IsTeam>
+  </Participants>
+  <Schedule>
+    <RaceId>K1M_ST_BR1_18</RaceId>
+    <ClassId>K1M_ST</ClassId>
+    <DisId>BR1</DisId>
+  </Schedule>
+  <Schedule>
+    <RaceId>K1M_ST_BR2_18</RaceId>
+    <ClassId>K1M_ST</ClassId>
+    <DisId>BR2</DisId>
+  </Schedule>
+  <Schedule>
+    <RaceId>K1M_ST_BR1_19</RaceId>
+    <ClassId>K1M_ST</ClassId>
+    <DisId>BR1</DisId>
+  </Schedule>
+  <Schedule>
+    <RaceId>K1M_ST_BR2_19</RaceId>
+    <ClassId>K1M_ST</ClassId>
+    <DisId>BR2</DisId>
+  </Schedule>
+  <Results>
+    <RaceId>K1M_ST_BR1_18</RaceId>
+    <Id>12054.K1M_ST</Id>
+    <Bib>1</Bib>
+    <Total>80000</Total>
+    <Rnk>1</Rnk>
+  </Results>
+  <Results>
+    <RaceId>K1M_ST_BR2_18</RaceId>
+    <Id>12054.K1M_ST</Id>
+    <Bib>1</Bib>
+    <Total>81000</Total>
+    <Rnk>1</Rnk>
+  </Results>
+  <Results>
+    <RaceId>K1M_ST_BR1_19</RaceId>
+    <Id>12054.K1M_ST</Id>
+    <Bib>1</Bib>
+    <Total>70000</Total>
+    <Rnk>1</Rnk>
+  </Results>
+  <Results>
+    <RaceId>K1M_ST_BR2_19</RaceId>
+    <Id>12054.K1M_ST</Id>
+    <Bib>1</Bib>
+    <Total>71000</Total>
+    <Rnk>1</Rnk>
+  </Results>
+</Canoe123Data>`;
+
+      await fsPromises.writeFile(xmlPath, xmlTwoDays);
+      service.setPath(xmlPath);
+
+      // Request merged for day 19 via BR2 raceId — must get day 19's BR1 paired in
+      const mergedDay19 = await service.getMergedResults('K1M_ST_BR2_19');
+      expect(mergedDay19).toHaveLength(1);
+      expect(mergedDay19[0].run1?.total).toBe(70000);
+      expect(mergedDay19[0].run2?.total).toBe(71000);
+
+      // Request via BR1 raceId must also return the same pair
+      const mergedDay19Br1 = await service.getMergedResults('K1M_ST_BR1_19');
+      expect(mergedDay19Br1[0].run1?.total).toBe(70000);
+      expect(mergedDay19Br1[0].run2?.total).toBe(71000);
+
+      // Day 18 must be returned intact when requested explicitly
+      const mergedDay18 = await service.getMergedResults('K1M_ST_BR2_18');
+      expect(mergedDay18[0].run1?.total).toBe(80000);
+      expect(mergedDay18[0].run2?.total).toBe(81000);
     });
   });
 });

--- a/src/unified/UnifiedServer.ts
+++ b/src/unified/UnifiedServer.ts
@@ -1470,7 +1470,7 @@ export class UnifiedServer extends EventEmitter<UnifiedServerEvents> {
           return;
         }
 
-        const results = await this.xmlDataService.getMergedResults(race.classId);
+        const results = await this.xmlDataService.getMergedResults(id);
         res.json({ results, merged: true, classId: race.classId });
         return;
       }


### PR DESCRIPTION
## Summary

- `XmlDataService.getMergedResults` now takes a **raceId** and derives the concrete BR1/BR2 sibling by swapping the run suffix, preserving the version/day. Fixes the bug where multi-day XML caused the endpoint to always return the first BR1/BR2 pair.
- Handlers in `UnifiedServer` and `AdminServer` forward the requested `id` (raceId) instead of `race.classId`.
- Added regression test covering two versions of the same class in the schedule.

Closes #81

## Test plan

- [x] `npm test -- --run src/service/__tests__/XmlDataService.test.ts` — 29 passed, including new regression test `pairs runs by version when multiple versions of the same class exist`
- [x] `npm run build` — clean TS build
- [ ] Manual verification on live server once deployed:
  - `curl http://<host>:27123/api/xml/races/K1M_BR2_19/results?merged=true` returns today's BR1 + BR2
  - `curl http://<host>:27123/api/xml/races/K1M_BR2_18/results?merged=true` returns yesterday's pair (intact)

## Notes

- The other 11 preexisting test failures (`ConfigPush`, `XmlFileSource`, `scoreboard-integration`) also fail on `main` and are unrelated to this change.
- Deploying requires a server restart — recommend doing it outside live race hours. The client-side of the scoreboard keeps working against the fixed endpoint without any changes on its side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)