### PR TITLE
fix: fetch correct event status on live reconnect

### DIFF
--- a/src/admin-ui/main.js
+++ b/src/admin-ui/main.js
@@ -1560,7 +1560,7 @@ async function loadBrowseEvents() {
         + '<span>' + escapeHtml(maskedKey) + '</span>'
         + '</div>'
         + '</div>'
-        + '<button class="btn btn-sm btn-primary" data-event-id="' + escapeHtml(ev.eventId) + '" data-api-key="' + escapeHtml(ev.apiKey) + '">Connect</button>'
+        + '<button class="btn btn-sm btn-primary" data-event-id="' + escapeHtml(ev.eventId) + '" data-api-key="' + escapeHtml(ev.apiKey) + '" data-event-status="' + escapeHtml(ev.status) + '">Connect</button>'
         + '</div>';
     }
     if (listEl) {
@@ -1568,7 +1568,7 @@ async function loadBrowseEvents() {
       // Event delegation for connect buttons (avoids inline JS / XSS)
       listEl.querySelectorAll('button[data-event-id]').forEach(function(btn) {
         btn.addEventListener('click', function() {
-          selectAndConnectEvent(btn.dataset.eventId, btn.dataset.apiKey);
+          selectAndConnectEvent(btn.dataset.eventId, btn.dataset.apiKey, btn.dataset.eventStatus);
         });
       });
     }
@@ -1593,12 +1593,14 @@ function closeSelectEventModal() {
 /**
  * Connect to a selected event from the list
  */
-async function selectAndConnectEvent(eventId, apiKey) {
+async function selectAndConnectEvent(eventId, apiKey, eventStatus) {
   try {
+    var body = { serverUrl: liveServerUrl, apiKey: apiKey, eventId: eventId };
+    if (eventStatus) body.eventStatus = eventStatus;
     var res = await fetch('/api/live/reconnect', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ serverUrl: liveServerUrl, apiKey: apiKey, eventId: eventId })
+      body: JSON.stringify(body)
     });
 
     var data = await res.json();

--- a/src/live/LivePusher.ts
+++ b/src/live/LivePusher.ts
@@ -13,9 +13,9 @@ import type { EventState } from '../state/EventState.js';
 import type { XmlChangeNotifier } from '../xml/XmlChangeNotifier.js';
 import type { EventStateData } from '../state/types.js';
 import type { XmlSection, ScheduleRace } from '../protocol/types.js';
-import { LiveClient } from './LiveClient.js';
+import { LiveClient, LiveApiError } from './LiveClient.js';
 import { LiveTransformer } from './LiveTransformer.js';
-import { deriveEventStatus, isForwardTransition } from './deriveEventStatus.js';
+import { deriveEventStatus, isForwardTransition, STATUS_ORDER } from './deriveEventStatus.js';
 import type {
   LiveStatus,
   ChannelStatus,
@@ -771,6 +771,19 @@ export class LivePusher extends EventEmitter<LivePusherEvents> {
     try {
       await this.transitionStatus(desired);
     } catch (error) {
+      // If the server reports its current status, sync our local state.
+      // This handles the case where we reconnected to an event that was
+      // already ahead of our local status (e.g., server at 'running',
+      // local at 'draft') — the server rejects the no-op transition but
+      // tells us where it actually is.
+      if (error instanceof LiveApiError && error.response?.currentStatus) {
+        const serverStatus = error.response.currentStatus as EventStatus;
+        if (serverStatus in STATUS_ORDER) {
+          Logger.info('LivePusher', `Auto-status: synced local status from server: ${serverStatus}`);
+          this.status.eventStatus = serverStatus;
+          this.emitStatusChange();
+        }
+      }
       // Clear cached statuses so the next state update re-triggers evaluation
       this.previousRaceStatuses.clear();
       Logger.warn('LivePusher', 'Auto-status: transition failed, will retry on next change', error);

--- a/src/live/__tests__/LivePusher.test.ts
+++ b/src/live/__tests__/LivePusher.test.ts
@@ -5,7 +5,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { EventEmitter } from 'node:events';
 import { LivePusher } from '../LivePusher.js';
-import { LiveClient } from '../LiveClient.js';
+import { LiveClient, LiveApiError } from '../LiveClient.js';
 import type { XmlDataService } from '../../service/XmlDataService.js';
 import type { EventState } from '../../state/EventState.js';
 import type { XmlChangeNotifier } from '../../xml/XmlChangeNotifier.js';
@@ -13,8 +13,11 @@ import type { EventStateData } from '../../state/types.js';
 import type { XmlSection } from '../../protocol/types.js';
 
 // Mock LiveClient (use regular function, not arrow, for constructor compatibility)
-vi.mock('../LiveClient.js', () => {
+// Preserve real LiveApiError for instanceof checks in auto-status recovery
+vi.mock('../LiveClient.js', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../LiveClient.js')>();
   return {
+    LiveApiError: original.LiveApiError,
     LiveClient: vi.fn().mockImplementation(function () {
       return {
         pushXml: vi.fn().mockResolvedValue({ imported: { classes: 1, categories: 1, races: 2, participants: 10 } }),
@@ -462,6 +465,83 @@ describe('LivePusher', () => {
       const status = pusher.getStatus();
       expect(status.state).toBe('not_configured');
       expect(statusHandler).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('auto-status recovery from server error', () => {
+    it('should sync local status from server error response with currentStatus', async () => {
+      // Setup schedule with races in progress so deriveEventStatus returns 'running'
+      const scheduleWithRunningRace = [
+        { raceId: 'K1M_1', raceStatus: 3, raceName: 'K1M Heat 1', startTime: '10:00' },
+      ];
+      (mockEventState as any).state.schedule = scheduleWithRunningRace;
+
+      await pusher.connect(
+        {
+          serverUrl: 'https://live.example.com',
+          apiKey: 'test-key',
+          eventId: 'event-123',
+          eventStatus: 'draft',
+          pushXml: false,
+          pushOnCourse: false,
+          pushResults: false,
+          autoStatus: true,
+        },
+        mockXmlChangeNotifier,
+        mockEventState,
+      );
+
+      // At connect, evaluateAutoStatus ran with the schedule.
+      // The default mock resolves successfully, so status should be 'running'.
+      expect(pusher.getStatus().eventStatus).toBe('running');
+    });
+
+    it('should recover status from LiveApiError.currentStatus on transition failure', async () => {
+      // Start with empty schedule so auto-status doesn't fire during connect
+      (mockEventState as any).state.schedule = [];
+
+      await pusher.connect(
+        {
+          serverUrl: 'https://live.example.com',
+          apiKey: 'test-key',
+          eventId: 'event-123',
+          eventStatus: 'draft',
+          pushXml: false,
+          pushOnCourse: false,
+          pushResults: false,
+          autoStatus: true,
+        },
+        mockXmlChangeNotifier,
+        mockEventState,
+      );
+
+      expect(pusher.getStatus().eventStatus).toBe('draft');
+
+      // Now make transitionStatus reject with LiveApiError containing currentStatus
+      const mockClient = (LiveClient as unknown as ReturnType<typeof vi.fn>).mock.results[0].value;
+      mockClient.transitionStatus.mockRejectedValueOnce(
+        new LiveApiError('Invalid transition', 400, {
+          error: 'INVALID_TRANSITION',
+          message: 'Cannot transition from running to running',
+          currentStatus: 'running',
+        }),
+      );
+
+      // Emit schedule change with races in progress → triggers evaluateAutoStatus
+      const newState = {
+        ...(mockEventState as any).state,
+        schedule: [
+          { raceId: 'K1M_1', raceStatus: 3, raceName: 'K1M Heat 1', startTime: '10:00' },
+        ],
+      };
+      (mockEventState as any).state = newState;
+      mockEventState.emit('change', newState);
+
+      // Wait for async evaluation
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // Local status should be synced from the server's currentStatus
+      expect(pusher.getStatus().eventStatus).toBe('running');
     });
   });
 });

--- a/src/unified/UnifiedServer.ts
+++ b/src/unified/UnifiedServer.ts
@@ -2902,7 +2902,7 @@ export class UnifiedServer extends EventEmitter<UnifiedServerEvents> {
       return;
     }
 
-    const { serverUrl, apiKey, eventId } = req.body;
+    const { serverUrl, apiKey, eventId, eventStatus } = req.body;
 
     if (!serverUrl || typeof serverUrl !== 'string') {
       res.status(400).json({ error: 'serverUrl is required' });
@@ -2917,10 +2917,16 @@ export class UnifiedServer extends EventEmitter<UnifiedServerEvents> {
       return;
     }
 
+    // Use provided event status (from browse events list) or default to 'draft'
+    const validStatuses: EventStatus[] = ['draft', 'startlist', 'running', 'finished', 'official'];
+    const initialStatus: EventStatus = (eventStatus && validStatuses.includes(eventStatus))
+      ? eventStatus
+      : 'draft';
+
     try {
       // Save connection to settings
       const settings = getAppSettings();
-      settings.setLiveConnection(serverUrl, apiKey, eventId, 'draft');
+      settings.setLiveConnection(serverUrl, apiKey, eventId, initialStatus);
 
       // Get updated config and connect pusher
       const liveConfig = settings.getLiveConfig();
@@ -2937,7 +2943,7 @@ export class UnifiedServer extends EventEmitter<UnifiedServerEvents> {
           serverUrl,
           apiKey,
           eventId,
-          eventStatus: 'draft',
+          eventStatus: initialStatus,
           pushXml: liveConfig.pushXml,
           pushOnCourse: liveConfig.pushOnCourse,
           pushResults: liveConfig.pushResults,


### PR DESCRIPTION
## Summary

- Reconnect to existing live event now uses the actual event status instead of always hardcoding `'draft'`
- Browse Events UI passes known status through the reconnect endpoint
- Auto-status evaluation recovers from server error responses containing `currentStatus`

Closes #79

## Root Cause

`handleLiveReconnect()` hardcoded `eventStatus: 'draft'` for both settings persistence and `LivePusher.connect()`. When the live server was already at the derived status (e.g., `running`), the transition was rejected as a no-op, leaving local status permanently stuck at `draft`.

## Changes

| File | Change |
|------|--------|
| `src/admin-ui/main.js` | Pass `ev.status` from event list to `selectAndConnectEvent`, include `eventStatus` in reconnect request |
| `src/unified/UnifiedServer.ts` | Accept optional `eventStatus` in reconnect body, validate against allowed values, use instead of `'draft'` |
| `src/live/LivePusher.ts` | In `evaluateAutoStatus` catch block: if `LiveApiError` has `currentStatus`, sync local status from server |
| `src/live/__tests__/LivePusher.test.ts` | Add tests for auto-status recovery from server error with `currentStatus` |

## Test plan

- [x] All 616 existing tests pass (1 e2e suite skipped — unrelated network 404)
- [x] New test: auto-status triggers on connect with schedule data
- [x] New test: local status syncs from `LiveApiError.currentStatus` on transition failure
- [ ] Manual: Browse Events → connect to event already at `running` → verify status shows `running`
- [ ] Manual: Manual Connect to event at `running` → verify auto-status recovers from server error

🤖 Generated with [Claude Code](https://claude.com/claude-code)