### PR TITLE
feat: add gates and courseNr to REST API

### DIFF
--- a/docs/REST-API.md
+++ b/docs/REST-API.md
@@ -281,7 +281,8 @@ Get race schedule (list of all races with times).
       "firstBib": "1",
       "startInterval": "60",
       "raceStatus": 5,
-      "customTitle": "K1m - short track - 1st run"
+      "customTitle": "K1m - short track - 1st run",
+      "courseNr": 1
     }
   ]
 }
@@ -295,6 +296,7 @@ Get race schedule (list of all races with times).
 | `raceStatus` | number | 3=Running, 5=Finished |
 | `startTime` | string | Scheduled start time (HH:MM:SS) |
 | `startInterval` | string | Interval between starts in seconds |
+| `courseNr` | number | Course number (1-based), maps to /api/xml/courses |
 
 ---
 
@@ -459,6 +461,7 @@ Get results for a specific race.
       "pen": 2,
       "total": 7899,
       "rank": 1,
+      "gates": "  0  0  2  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0",
       "participant": {
         "id": "12054.K1M_ST",
         "classId": "K1M_ST",
@@ -480,6 +483,7 @@ Get results for a specific race.
 | `total` | number | Total time in centiseconds |
 | `rank` | number | Position in results |
 | `status` | string | Empty for valid, `DSQ`, `DNS`, `DNF` for invalid |
+| `gates` | string | Space-separated per-gate penalties (0, 2, or 50) |
 
 **Response (merged=true):**
 

--- a/src/service/XmlDataService.ts
+++ b/src/service/XmlDataService.ts
@@ -35,6 +35,7 @@ export interface XmlScheduleItem {
   startInterval?: string | undefined;
   raceStatus?: number | undefined;
   customTitle?: string | undefined;
+  courseNr?: number | undefined;
 }
 
 /**
@@ -56,6 +57,7 @@ export interface XmlResultRow {
   prevPen?: number | undefined;
   prevTotal?: number | undefined;
   prevRank?: number | undefined;
+  gates?: string | undefined;
 }
 
 /**
@@ -660,6 +662,7 @@ export class XmlDataService {
         startInterval: s.StartInterval ? String(s.StartInterval) : undefined,
         raceStatus: s.RaceStatus !== undefined ? Number(s.RaceStatus) : undefined,
         customTitle: s.CustomTitle ? String(s.CustomTitle) : undefined,
+        courseNr: s.CourseNr !== undefined ? Number(s.CourseNr) : undefined,
       }));
   }
 
@@ -697,6 +700,7 @@ export class XmlDataService {
         prevPen: r.PrevPen !== undefined ? Number(r.PrevPen) : undefined,
         prevTotal: r.PrevTotal !== undefined ? Number(r.PrevTotal) : undefined,
         prevRank: r.PrevRnk !== undefined ? Number(r.PrevRnk) : undefined,
+        gates: r.Gates ? String(r.Gates) : undefined,
       };
 
       if (!resultsMap.has(raceId)) {
@@ -797,6 +801,7 @@ interface RawSchedule {
   StartInterval?: string;
   RaceStatus?: string | number;
   CustomTitle?: string;
+  CourseNr?: string | number;
 }
 
 interface RawResult {
@@ -815,6 +820,7 @@ interface RawResult {
   PrevPen?: string | number;
   PrevTotal?: string | number;
   PrevRnk?: string | number;
+  Gates?: string | number;
 }
 
 interface RawCourseData {

--- a/src/service/__tests__/XmlDataService.test.ts
+++ b/src/service/__tests__/XmlDataService.test.ts
@@ -48,6 +48,7 @@ describe('XmlDataService', () => {
     <StartInterval>0:45</StartInterval>
     <RaceStatus>5</RaceStatus>
     <CustomTitle>K1m - střední trať - 1. jízda</CustomTitle>
+    <CourseNr>1</CourseNr>
   </Schedule>
   <Schedule>
     <RaceId>K1M_ST_BR2_6</RaceId>
@@ -72,6 +73,7 @@ describe('XmlDataService', () => {
     <Total>78990</Total>
     <Rnk>1</Rnk>
     <CatRnk>1</CatRnk>
+    <Gates>  0  2  0  50  0  0</Gates>
   </Results>
   <Results>
     <RaceId>K1M_ST_BR1_6</RaceId>
@@ -173,6 +175,7 @@ describe('XmlDataService', () => {
         disId: 'BR1',
         raceStatus: 5,
         customTitle: 'K1m - střední trať - 1. jízda',
+        courseNr: 1,
       });
 
       expect(schedule[1]).toMatchObject({
@@ -181,6 +184,15 @@ describe('XmlDataService', () => {
         disId: 'BR2',
         raceStatus: 3,
       });
+    });
+
+    it('parses courseNr as a number', async () => {
+      service.setPath(xmlPath);
+      const schedule = await service.getSchedule();
+
+      expect(typeof schedule[0].courseNr).toBe('number');
+      expect(schedule[0].courseNr).toBe(1);
+      expect(schedule[1].courseNr).toBeUndefined();
     });
   });
 
@@ -204,6 +216,16 @@ describe('XmlDataService', () => {
         total: 78990,
         rank: 1,
       });
+    });
+
+    it('returns gates as a string when present', async () => {
+      service.setPath(xmlPath);
+      const results = await service.getAllResults();
+
+      const raceResults = results.get('K1M_ST_BR1_6')!;
+      expect(typeof raceResults[0].gates).toBe('string');
+      expect(raceResults[0].gates).toBe('  0  2  0  50  0  0');
+      expect(raceResults[1].gates).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
## Summary

- Add `gates` field (space-separated per-gate penalties) to `GET /api/xml/races/:id/results` response
- Add `courseNr` field (course number, maps to `/api/xml/courses`) to `GET /api/xml/schedule` response

Both fields already exist in the C123 XML data but were not exposed via REST API.

Requested by c123-penalty-check#39 for pre-loading race data and per-race gate configuration.

## Test plan

- [x] Unit tests for both new fields
- [x] 618 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)