### PR TITLE
feat: add browseAfterHighlight param to admin UI and client config

### DIFF
--- a/docs/CLIENT-CONFIG.md
+++ b/docs/CLIENT-CONFIG.md
@@ -48,6 +48,7 @@ These parameters are recognized by the C123 Server and scoreboard implementation
 | `showOnCourse` | boolean | true/false | Show OnCourse data |
 | `showResults` | boolean | true/false | Show Results data |
 | `scrollToFinished` | boolean | true/false | Scroll to finished competitor (default: true) |
+| `browseAfterHighlight` | boolean | true/false | Browse results after highlight (default: false) |
 | `assets` | object | AssetUrls | Logo and banner images (see below) |
 
 ### Asset Parameters
@@ -110,6 +111,7 @@ Sent by server when:
 | `showOnCourse` | boolean | Show OnCourse data |
 | `showResults` | boolean | Show Results data |
 | `scrollToFinished` | boolean | Scroll to finished competitor (default: true) |
+| `browseAfterHighlight` | boolean | Browse results after highlight (default: false) |
 | `custom` | object | Custom parameters (key-value) |
 | `label` | string | Admin-assigned label |
 | `clientId` | string | Server-assigned client identifier (see below) |
@@ -193,6 +195,7 @@ interface ConfigPushData {
   showOnCourse?: boolean;
   showResults?: boolean;
   scrollToFinished?: boolean;
+  browseAfterHighlight?: boolean;
   custom?: Record<string, string | number | boolean>;
   label?: string;
   assets?: AssetUrls;
@@ -481,7 +484,7 @@ Update configuration for a client. Automatically pushes changes if client is onl
 - `type`: Must be `'vertical'` or `'ledwall'`
 - `displayRows`: Must be 3-20
 - `raceFilter`: Must be an array of strings
-- `showOnCourse`, `showResults`, `scrollToFinished`: Must be boolean
+- `showOnCourse`, `showResults`, `scrollToFinished`, `browseAfterHighlight`: Must be boolean
 
 ### PUT /api/clients/:ip/label
 

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -673,6 +673,7 @@ interface ConfigPushData {
   showOnCourse?: boolean;
   showResults?: boolean;
   scrollToFinished?: boolean;  // Whether to scroll to finished competitor (default: true)
+  browseAfterHighlight?: boolean;  // Browse results after highlight (default: false)
   custom?: Record<string, string | number | boolean>;
   label?: string;
 }
@@ -692,6 +693,7 @@ function applyConfig(config: ConfigPushData) {
   if (config.customTitle) setTitle(config.customTitle);
   // scrollToFinished: default true, only apply if explicitly set to false
   if (config.scrollToFinished === false) disableScrollToFinished();
+  if (config.browseAfterHighlight) enableBrowseAfterHighlight();
 
   // Handle custom parameters
   if (config.custom) {

--- a/docs/REST-API.md
+++ b/docs/REST-API.md
@@ -1067,6 +1067,7 @@ Update configuration for a client. If the client is online, changes are pushed i
 | `showOnCourse` | boolean | true/false | Show OnCourse data |
 | `showResults` | boolean | true/false | Show Results data |
 | `scrollToFinished` | boolean | true/false | Scroll to finished competitor (default: true) |
+| `browseAfterHighlight` | boolean | true/false | Browse results after highlight (default: false) |
 | `custom` | object | key-value pairs | Custom parameters |
 | `clientId` | string | non-empty string | Server-assigned client ID (client adopts it) |
 
@@ -1098,6 +1099,7 @@ Update configuration for a client. If the client is online, changes are pushed i
 | 400 | `{ "error": "Invalid type. Must be 'vertical' or 'ledwall'." }` |
 | 400 | `{ "error": "displayRows must be between 3 and 20." }` |
 | 400 | `{ "error": "scrollToFinished must be a boolean" }` |
+| 400 | `{ "error": "browseAfterHighlight must be a boolean" }` |
 
 ---
 

--- a/src/admin-ui/index.html
+++ b/src/admin-ui/index.html
@@ -575,6 +575,12 @@
                   <span class="modal-checkbox-label">Scroll to finished competitor</span>
                 </label>
               </div>
+              <div class="modal-field">
+                <label class="modal-checkbox">
+                  <input type="checkbox" id="modalBrowseAfterHighlight">
+                  <span class="modal-checkbox-label">Browse results after highlight</span>
+                </label>
+              </div>
             </fieldset>
           </div>
 

--- a/src/admin-ui/main.js
+++ b/src/admin-ui/main.js
@@ -940,6 +940,7 @@ function openClientModal(configKey) {
   document.getElementById('modalClientId').value = cfg.clientId || '';
   // scrollToFinished: default true if not set
   document.getElementById('modalScrollToFinished').checked = cfg.scrollToFinished !== false;
+  document.getElementById('modalBrowseAfterHighlight').checked = cfg.browseAfterHighlight === true;
 
   // Load assets into modal
   loadModalAssets(cfg.assets);
@@ -1007,6 +1008,7 @@ async function saveClientConfig() {
   // Send clientId if set (allows server to assign/rename client identity)
   if (clientId) config.clientId = clientId;
   config.scrollToFinished = document.getElementById('modalScrollToFinished').checked;
+  config.browseAfterHighlight = document.getElementById('modalBrowseAfterHighlight').checked;
 
   // Include asset overrides if any have been modified
   if (Object.keys(modalAssets).length > 0) {

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -76,6 +76,8 @@ export interface ClientConfig {
 
   /** Whether to scroll to finished competitor (default: true). When false, only highlights without scrolling. */
   scrollToFinished?: boolean;
+  /** Whether to slowly browse through results after highlighting finished competitor (default: false). */
+  browseAfterHighlight?: boolean;
 
   // === Custom parameters (key-value for additional/future parameters) ===
 

--- a/src/unified/UnifiedServer.ts
+++ b/src/unified/UnifiedServer.ts
@@ -2008,6 +2008,11 @@ export class UnifiedServer extends EventEmitter<UnifiedServerEvents> {
       return;
     }
 
+    if (config.browseAfterHighlight !== undefined && typeof config.browseAfterHighlight !== 'boolean') {
+      res.status(400).json({ error: 'browseAfterHighlight must be a boolean' });
+      return;
+    }
+
     if (config.clientId !== undefined) {
       if (typeof config.clientId !== 'string' || config.clientId.trim() === '') {
         res.status(400).json({ error: 'clientId must be a non-empty string' });


### PR DESCRIPTION
## Summary

- Adds `browseAfterHighlight` boolean to `ClientConfig` type, REST API validation, and admin UI
- Enables admins to toggle slow-scroll browsing through results after the scoreboard highlights a finished competitor
- Follows the exact same pattern as `scrollToFinished` — default `false` (opt-in)

Configures the scoreboard-side feature from OpenCanoeTiming/c123-scoreboard#50.

Closes #89

## Changes

| File | Change |
|------|--------|
| `src/config/types.ts` | New `browseAfterHighlight?: boolean` in ClientConfig |
| `src/unified/UnifiedServer.ts` | Boolean validation in PUT `/api/clients/:ip/config` |
| `src/admin-ui/index.html` | Checkbox "Browse results after highlight" in client modal |
| `src/admin-ui/main.js` | Load (default false) + save checkbox value |

## Test plan

- [ ] Open admin UI → client config modal → verify new checkbox appears below "Scroll to finished"
- [ ] Check/uncheck and save → verify config is persisted (GET `/api/clients`)
- [ ] Verify ConfigPush WebSocket message includes `browseAfterHighlight` when set
- [ ] Send non-boolean via REST API → verify 400 response

🤖 Generated with [Claude Code](https://claude.com/claude-code)