### PR TITLE
fix: trim bib at XML extraction boundary

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,15 @@
 # C123 Server - Development Log
 
+## 2026-04-29 — Bib whitespace audit after trimValues: false (issue #80)
+
+**Problem:** PR #77 set `trimValues: false` globally on all XML parsers to preserve fixed-width `@_Gates` strings. Side effect: `@_Bib` (right-aligned 4-char field like `"  44"`) was emitted untrimmed via WebSocket while REST API trimmed it. Downstream scoreboard cache keyed by REST bibs couldn't look up WS bibs — 100% miss rate during Jarni slalomy 2026-04-18 BR2 race.
+
+**Attempted:** Scoreboard patched defensively (f000c07). But server was the source of asymmetry.
+
+**Solution:** Trim `@_Bib` at the two extraction sites in `xml-parser.ts` (parseOnCourseEntry, parseResults). Documented the `trimValues: false` convention with comments on all three parser instances. Audit confirmed only `@_Bib` and `@_Ranking` (already trimmed in XmlDataService) had real XML padding — other attributes (Name, Club, Nat, RaceId, etc.) are clean in source XML.
+
+**Lesson:** Global parser config changes are not local fixes. Every attribute must be analyzed for impact. The fix belongs at the extraction boundary, not at the parser flag level.
+
 ## 2026-04-12 ��� Service → tray app: Gemini caught three missing concerns (#72)
 
 **Problem:** Plan to replace Windows service with user-launched tray app looked complete, but /second-opinion (Gemini) flagged three user-facing gaps: (1) no single-instance guard — user could accidentally launch twice from Start Menu and get a confusing EADDRINUSE error, (2) no process termination during upgrade/uninstall — Inno Setup had `CloseApplications=no` for the service model but now the running node.exe holds file locks, (3) removing `setupTrayFileLog()` left the wscript.exe-launched server with zero diagnostics on crash.

--- a/src/protocol/__tests__/xml-parser.test.ts
+++ b/src/protocol/__tests__/xml-parser.test.ts
@@ -323,6 +323,46 @@ describe('parseXmlMessage', () => {
     }
   });
 
+  it('trims right-aligned bib padding in OnCourse (issue #80)', () => {
+    // C123 emits Bib as right-aligned 4-char field: "  44", " 128"
+    // trimValues: false preserves this padding, but bib must be trimmed
+    // at extraction to avoid WS/REST asymmetry (scoreboard cache miss)
+    const xml =
+      '<Canoe123 System="Main">' +
+      '<OnCourse Total="1" Position="1">' +
+      '<Participant Bib="  44" Name="TEST" Club="" Nat="" Race="" RaceId="TEST" Warning="" />' +
+      '<Result Type="C" Gates="0,0,0,2,," Completed="N" dtStart="10:00:00.000" />' +
+      '<Result Type="T" Pen="6" Time="5000" Rank="1" />' +
+      '</OnCourse>' +
+      '</Canoe123>';
+
+    const results = parseXmlMessage(xml);
+    const data = results[0].data;
+    expect(data).not.toBeNull();
+    if (data && 'competitors' in data) {
+      expect(data.competitors[0].bib).toBe('44');
+    }
+  });
+
+  it('trims right-aligned bib padding in Results (issue #80)', () => {
+    const xml =
+      '<Canoe123 System="Main">' +
+      '<Results RaceId="TEST" Current="Y" MainTitle="Test" SubTitle="">' +
+      '<Row Number="1">' +
+      '<Participant Bib=" 128" Name="TEST" GivenName="T" FamilyName="TEST" Club="" StartOrder="1" StartTime="" />' +
+      '<Result Type="T" Pen="0" Time="80.00" Total="80.00" Rank="1" Behind="" />' +
+      '</Row>' +
+      '</Results>' +
+      '</Canoe123>';
+
+    const results = parseXmlMessage(xml);
+    const data = results[0].data;
+    expect(data).not.toBeNull();
+    if (data && 'rows' in data) {
+      expect(data.rows[0].bib).toBe('128');
+    }
+  });
+
   it('preserves fully-scored gates without trimming (issue #75)', () => {
     const fullGates = '  0  0  0  0  2  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  2';
     const xml =

--- a/src/protocol/xml-parser.ts
+++ b/src/protocol/xml-parser.ts
@@ -11,6 +11,10 @@ import type {
   ScheduleRace,
 } from './parser-types.js';
 
+// trimValues: false preserves whitespace in XML attribute values.
+// Required for @_Gates which uses fixed-width positional encoding (issue #75).
+// All other attributes that need clean values are trimmed explicitly at
+// extraction (e.g. bib.trim()). Do not re-enable trimValues.
 const parser = new XMLParser({
   ignoreAttributes: false,
   attributeNamePrefix: '@_',

--- a/src/protocol/xml-parser.ts
+++ b/src/protocol/xml-parser.ts
@@ -155,7 +155,7 @@ function parseOnCourseEntry(entry: unknown, position: number): OnCourseCompetito
     return null;
   }
 
-  const bib = String(participant['@_Bib'] ?? '');
+  const bib = String(participant['@_Bib'] ?? '').trim();
   if (!bib) {
     return null;
   }
@@ -229,7 +229,7 @@ export function parseResults(element: unknown): ResultsMessage | null {
 
       if (!participant) continue;
 
-      const bib = String(participant['@_Bib'] ?? '');
+      const bib = String(participant['@_Bib'] ?? '').trim();
       if (!bib) continue;
 
       // Find Result Type="T"

--- a/src/service/XmlDataService.ts
+++ b/src/service/XmlDataService.ts
@@ -168,6 +168,9 @@ export class XmlDataService {
   private readonly parser: XMLParser;
 
   constructor() {
+    // trimValues: false — must match protocol parser.
+    // See xml-parser.ts for rationale (issue #75).
+    // String fields trimmed at extraction (e.g. bib, ranking).
     this.parser = new XMLParser({
       ignoreAttributes: false,
       attributeNamePrefix: '@_',

--- a/src/xml/XmlChangeNotifier.ts
+++ b/src/xml/XmlChangeNotifier.ts
@@ -68,6 +68,8 @@ export class XmlChangeNotifier extends EventEmitter<XmlChangeNotifierEvents> {
     this.pollInterval = config.pollInterval ?? 1000;
     this.debounceMs = config.debounceMs ?? 100;
 
+    // trimValues: false — must match protocol parser for consistent hashing.
+    // See xml-parser.ts for rationale (issue #75).
     this.parser = new XMLParser({
       ignoreAttributes: false,
       attributeNamePrefix: '@_',


### PR DESCRIPTION
## Summary

- Add `.trim()` to `@_Bib` extraction at both sites in `xml-parser.ts` (parseOnCourseEntry, parseResults) — fixes WS/REST asymmetry where WebSocket emitted `"  44"` but REST returned `"44"`
- Document `trimValues: false` convention with comments on all three XMLParser instances
- Add pin tests verifying padded bibs are trimmed while gates remain untrimmed

**Root cause:** PR #77 set `trimValues: false` globally to preserve fixed-width `@_Gates`. Side effect: right-aligned `@_Bib` (4-char field) passed untrimmed through WebSocket, causing cache key mismatches in c123-scoreboard during Jarni slalomy 2026-04-18.

**Audit scope:** Inventoried all XML attribute extractions across `xml-parser.ts`, `XmlDataService.ts`, `XmlChangeNotifier.ts`. Cross-referenced with real XML samples and all downstream consumers (c123-scoreboard, c123-penalty-check). Only `@_Bib` needed fixing — `@_Ranking` already trimmed in XmlDataService, all other attributes have no padding in source XML.

Closes #80

## Test plan

- [ ] `npx vitest run src/protocol/__tests__/xml-parser.test.ts` — 24 tests pass (including 2 new bib trim + 3 existing gates preservation)
- [ ] `npx vitest run` — full suite passes (e2e-recording timeout is pre-existing, unrelated)
- [ ] Verify c123-penalty-check Map lookups work with trimmed bibs (no client-side changes needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)