### PR TITLE
docs: sync REST/WebSocket API docs with current implementation

### DIFF
--- a/docs/C123-PROTOCOL.md
+++ b/docs/C123-PROTOCOL.md
@@ -3,8 +3,8 @@
 This document describes the WebSocket protocol provided by C123 Server for scoreboard clients.
 
 > **Note:** For documentation of the native Canoe123 TCP/UDP protocol (XML format, network architecture), see:
-> - `analysis/c123-protocol.md` - Native network protocol
-> - `analysis/c123-xml-format.md` - XML file export format
+> - `../c123-protocol-docs/c123-protocol.md` - Native network protocol
+> - `../c123-protocol-docs/c123-xml-format.md` - XML file export format
 
 ---
 
@@ -12,8 +12,13 @@ This document describes the WebSocket protocol provided by C123 Server for score
 
 C123 Server connects to Canoe123 via TCP:27333 and transforms XML messages to JSON, providing:
 
-- **WebSocket API** at `ws://server:3001/ws` for real-time data
-- **REST API** at `http://server:3001/api` for static data and XML access
+- **WebSocket API** at `ws://server:27123/ws` for real-time data
+- **REST API** at `http://server:27123/api` for static data and XML access
+
+Everything runs on a single port (**27123**). Two kinds of WebSocket connection exist:
+
+- **Scoreboard** — `ws://server:27123/ws` (optionally `?clientId=<id>`): receives C123 data, `Connected`, `ConfigPush`, `ForceRefresh`, `XmlChange`, and `XmlMismatch`.
+- **Admin dashboard** — `ws://server:27123/ws?admin=1`: additionally receives monitoring messages (`LogEntry`, `ScoringEvent`, `LiveStatus`, `ClientsUpdate`).
 
 ---
 
@@ -233,6 +238,26 @@ Sent when XML file changes:
 }
 ```
 
+Possible `sections` values: `Participants`, `Schedule`, `Results`, `Classes`.
+
+### XmlMismatch
+
+Sent when the loaded XML file does not match the live C123 schedule (wrong file selected), and again with `detected: false` when resolved. Also available via `GET /api/xml/mismatch`.
+
+```json
+{
+  "type": "XmlMismatch",
+  "timestamp": "2025-01-02T10:31:00.000Z",
+  "data": {
+    "detected": true,
+    "tcpFingerprint": "K1M_ST_BR1|K1W_ST_BR1|...",
+    "xmlFingerprint": "C1M_ST_BR1|C1W_ST_BR1|...",
+    "unmatchedRaceIds": ["K1M_ST_BR1_6"],
+    "message": "XML file does not match C123 live data"
+  }
+}
+```
+
 ### ForceRefresh
 
 Admin-triggered refresh command:
@@ -272,7 +297,7 @@ See [CLIENT-CONFIG.md](CLIENT-CONFIG.md) for complete configuration documentatio
 
 ### LogEntry
 
-Real-time log for admin dashboard:
+Real-time log for admin dashboard. **Admin connections only** (`?admin=1`).
 
 ```json
 {
@@ -283,6 +308,54 @@ Real-time log for admin dashboard:
     "component": "TcpSource",
     "message": "Connected to C123"
   }
+}
+```
+
+### ScoringEvent
+
+Broadcast when a C123 write command (penalty, remove, timing) is successfully sent. **Admin connections only.**
+
+```json
+{
+  "type": "ScoringEvent",
+  "timestamp": "2025-01-16T12:30:00.000Z",
+  "data": {
+    "eventType": "penalty",
+    "bib": "10",
+    "details": { "gate": 5, "value": 2 }
+  }
+}
+```
+
+| eventType | details |
+|-----------|---------|
+| `penalty` | `{ gate, value, raceId? }` (`raceId` for finished-competitor corrections) |
+| `remove` | `{ reason: "DNS" \| "DNF" \| "CAP", position }` |
+| `timing` | `{ channelPosition: "Start" \| "Finish" \| "Split1" \| "Split2" }` |
+
+See [REST-API.md](REST-API.md#c123-write-api) for the originating endpoints.
+
+### LiveStatus
+
+Status of the Live-Mini pusher (push to a remote `c123-live` server). Sent on every state change, throttled to max 2/s. **Admin connections only.** The `data` payload matches the `status` object from `GET /api/live/status`.
+
+```json
+{
+  "type": "LiveStatus",
+  "timestamp": "2025-01-02T10:31:00.000Z",
+  "data": { "state": "connected", "eventId": "czech-cup-2025", "...": "..." }
+}
+```
+
+### ClientsUpdate
+
+The current list of connected/known scoreboard clients, sent on connect, disconnect, or session update. **Admin connections only.** The `data.clients` array matches `GET /api/clients`.
+
+```json
+{
+  "type": "ClientsUpdate",
+  "timestamp": "2025-01-05T10:30:00.000Z",
+  "data": { "clients": [ { "ip": "192.168.1.50", "online": true, "...": "..." } ] }
 }
 ```
 
@@ -357,4 +430,4 @@ See [INTEGRATION.md](INTEGRATION.md#br1br2-merge-strategy) for details.
 - [XML-FORMAT.md](XML-FORMAT.md) - XML file format with examples
 - [CLIENT-CONFIG.md](CLIENT-CONFIG.md) - Remote client configuration
 - [INTEGRATION.md](INTEGRATION.md) - Scoreboard integration guide
-- `analysis/c123-protocol.md` - Native C123 TCP/UDP protocol (detailed)
+- `../c123-protocol-docs/c123-protocol.md` - Native C123 TCP/UDP protocol (detailed)

--- a/docs/REST-API.md
+++ b/docs/REST-API.md
@@ -11,8 +11,9 @@ The C123 Server provides the following APIs:
 | Category | Base URL | Description |
 |----------|----------|-------------|
 | **Discovery API** | `/api/discover` | Server identification for auto-discovery |
+| **Update Check API** | `/api/update-check` | Check GitHub Releases for a newer server version |
 | **Server API** | `/api` | Server status, sources, scoreboards |
-| **XML Data API** | `/api/xml` | Race data from XML file (schedule, results, participants) |
+| **XML Data API** | `/api/xml` | Race data from XML file (schedule, results, participants, mismatch) |
 | **Configuration API** | `/api/config` | Server configuration (XML source, event name) |
 | **Event API** | `/api/event` | Event name management |
 | **Broadcast API** | `/api/broadcast` | Broadcast messages to all clients |
@@ -61,6 +62,39 @@ Access-Control-Allow-Methods: GET, OPTIONS
 
 ---
 
+## Update Check API
+
+### GET /api/update-check
+
+Check GitHub Releases for a newer stable server version. Used by the admin dashboard to show an update banner.
+
+**Fail-safe by design:** any error (network, timeout, parse, disabled) returns HTTP `200` with `latest: null` and `isNewer: false` (plus an optional `error` field) so the dashboard never breaks. Results are cached for 1 hour to avoid hitting the GitHub API on every load. Prerelease/preview builds are ignored. Can be disabled with `{ "updateCheck": false }` in `settings.json` for closed networks.
+
+**Response:**
+
+```json
+{
+  "current": "0.9.0",
+  "latest": "0.10.0",
+  "url": "https://github.com/OpenCanoeTiming/c123-server/releases/tag/v0.10.0",
+  "isNewer": true,
+  "checkedAt": 1736000000000,
+  "enabled": true
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `current` | string | Installed server version (from `package.json`) |
+| `latest` | string \| null | Latest stable release version, or `null` on error/disabled |
+| `url` | string \| null | Release page URL, or `null` |
+| `isNewer` | boolean | `true` if `latest` is newer than `current` |
+| `checkedAt` | number | Epoch milliseconds when the check ran |
+| `enabled` | boolean | `false` if update checks are disabled via settings |
+| `error` | string | (optional) Reason the check failed (still HTTP 200) |
+
+---
+
 ## Server Status API
 
 ### GET /api/status
@@ -71,7 +105,7 @@ Get overall server status including uptime, connected scoreboards, and current e
 
 ```json
 {
-  "version": "0.9.0",
+  "version": "2.0.0",
   "uptime": 3600,
   "sources": [
     {
@@ -613,6 +647,44 @@ Get course configuration data including gate setup and split positions.
 
 ---
 
+### GET /api/xml/mismatch
+
+Get the current XML/TCP mismatch state. The server compares the schedule fingerprint from the live C123 TCP feed against the loaded XML file; a mismatch means the XML file does not belong to the currently running event (wrong file selected).
+
+**Response (no mismatch):**
+
+```json
+{
+  "detected": false
+}
+```
+
+**Response (mismatch detected):**
+
+```json
+{
+  "detected": true,
+  "detectedAt": "2025-01-02T10:30:00.000Z",
+  "tcpFingerprint": "K1M_ST_BR1|K1W_ST_BR1|...",
+  "xmlFingerprint": "C1M_ST_BR1|C1W_ST_BR1|...",
+  "unmatchedRaceIds": ["K1M_ST_BR1_6"],
+  "message": "XML file does not match C123 live data"
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `detected` | boolean | Whether a mismatch is currently active |
+| `detectedAt` | string | (optional) ISO timestamp when first detected |
+| `tcpFingerprint` | string | (optional) Schedule fingerprint from the C123 TCP feed |
+| `xmlFingerprint` | string | (optional) Schedule fingerprint from the XML file |
+| `unmatchedRaceIds` | string[] | (optional) Race IDs present in TCP but not matched in XML |
+| `message` | string | (optional) Human-readable explanation |
+
+The same information is pushed in real time to WebSocket clients via the `XmlMismatch` message — see [C123-PROTOCOL.md](C123-PROTOCOL.md).
+
+---
+
 ## Broadcast API
 
 ### POST /api/broadcast/refresh
@@ -1076,21 +1148,23 @@ Update configuration for a client. If the client is online, changes are pushed i
 ```json
 {
   "success": true,
+  "ip": "192.168.1.50",
   "config": {
     "type": "ledwall",
     "displayRows": 10,
     "customTitle": "Finish Line",
     "label": "TV in Hall A"
   },
-  "pushed": true
+  "pushedToSessions": 1
 }
 ```
 
 | Field | Type | Description |
 |-------|------|-------------|
 | `success` | boolean | Operation succeeded |
+| `ip` | string | Client config key (IP or clientId) |
 | `config` | object | Updated configuration |
-| `pushed` | boolean | Whether config was pushed to online client |
+| `pushedToSessions` | number | Number of online sessions the config was pushed to |
 
 **Errors:**
 
@@ -1128,16 +1202,23 @@ Set label for a client.
 
 ### DELETE /api/clients/:ip
 
-Delete stored configuration for a client.
+Delete stored configuration for a client. Does not disconnect an online client.
 
 **Response:**
 
 ```json
 {
   "success": true,
-  "deleted": true
+  "ip": "192.168.1.50",
+  "message": "Client configuration deleted"
 }
 ```
+
+**Errors:**
+
+| Status | Response |
+|--------|----------|
+| 404 | `{ "error": "Client configuration not found" }` |
 
 ---
 
@@ -1158,9 +1239,16 @@ Send ForceRefresh to a specific client.
 ```json
 {
   "success": true,
-  "refreshed": true
+  "ip": "192.168.1.50",
+  "sessionsRefreshed": 1,
+  "reason": "Manual refresh"
 }
 ```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `sessionsRefreshed` | number | Number of online sessions refreshed |
+| `reason` | string \| null | The reason sent to the client (or `null`) |
 
 **Errors:**
 
@@ -1427,12 +1515,26 @@ These endpoints allow sending commands to the C123 timing system. Commands are s
 
 ### POST /api/c123/scoring
 
-Send a penalty scoring command to C123.
+Send a penalty scoring command to C123. The endpoint has two modes depending on whether `raceId` is supplied:
 
-**Request:**
+- **Without `raceId`** — scoring for a competitor currently **on course** (live).
+- **With `raceId`** — penalty **correction** for an already **finished** competitor in a specific race.
+
+**Request (on-course):**
 
 ```json
 {
+  "bib": "10",
+  "gate": 5,
+  "value": 2
+}
+```
+
+**Request (penalty correction for a finished competitor):**
+
+```json
+{
+  "raceId": "K1M_ST_BR2_6",
   "bib": "10",
   "gate": 5,
   "value": 2
@@ -1444,6 +1546,7 @@ Send a penalty scoring command to C123.
 | `bib` | string | Yes | Non-empty | Competitor start number |
 | `gate` | number | Yes | 1-24 | Gate number |
 | `value` | number\|null | Yes | 0, 2, 50, or null | Penalty value (null to delete) |
+| `raceId` | string | No | Non-empty if present | Target race; switches to penalty-correction mode for a finished competitor |
 
 **Penalty Values:**
 
@@ -1459,19 +1562,25 @@ Send a penalty scoring command to C123.
 ```json
 {
   "success": true,
+  "raceId": "K1M_ST_BR2_6",
   "bib": "10",
   "gate": 5,
   "value": 2
 }
 ```
 
+`raceId` is omitted from the response in on-course mode.
+
 **Errors:**
 
 | Status | Response |
 |--------|----------|
 | 400 | `{ "error": "bib is required" }` |
+| 400 | `{ "error": "gate is required" }` |
 | 400 | `{ "error": "gate must be a number between 1 and 24" }` |
+| 400 | `{ "error": "value is required (use null to delete)" }` |
 | 400 | `{ "error": "value must be 0, 2, 50, or null (to delete)" }` |
+| 400 | `{ "error": "raceId must be a non-empty string if provided" }` |
 | 503 | `{ "error": "Not connected to C123", "detail": "TCP connection to C123 is not established" }` |
 
 ---
@@ -1593,7 +1702,7 @@ When a C123 command is successfully sent, a `ScoringEvent` message is broadcast 
 
 | eventType | details |
 |-----------|---------|
-| `penalty` | `{ gate: number, value: 0 \| 2 \| 50 }` |
+| `penalty` | `{ gate: number, value: 0 \| 2 \| 50 \| null, raceId?: string }` (`raceId` present for finished-competitor corrections) |
 | `remove` | `{ reason: "DNS" \| "DNF" \| "CAP", position: number }` |
 | `timing` | `{ channelPosition: "Start" \| "Finish" \| "Split1" \| "Split2" }` |
 
@@ -1859,7 +1968,7 @@ Transition the event status on the live server.
 
 ### PATCH /api/live/config
 
-Toggle push channels on/off. At least one channel must be specified.
+Update push channels and automatic status transitions. At least one field must be specified.
 
 **Request:**
 
@@ -1867,7 +1976,8 @@ Toggle push channels on/off. At least one channel must be specified.
 {
   "pushXml": true,
   "pushOnCourse": true,
-  "pushResults": false
+  "pushResults": false,
+  "autoStatus": true
 }
 ```
 
@@ -1876,6 +1986,7 @@ Toggle push channels on/off. At least one channel must be specified.
 | `pushXml` | boolean | No | Enable/disable XML push |
 | `pushOnCourse` | boolean | No | Enable/disable OnCourse push |
 | `pushResults` | boolean | No | Enable/disable Results push |
+| `autoStatus` | boolean | No | Enable/disable automatic event status transitions (e.g. running → finished) |
 
 **Response:**
 
@@ -1887,6 +1998,7 @@ Toggle push channels on/off. At least one channel must be specified.
     "oncourse": true,
     "results": false
   },
+  "autoStatus": true,
   "status": { "..." }
 }
 ```
@@ -1897,6 +2009,85 @@ Toggle push channels on/off. At least one channel must be specified.
 |--------|----------|
 | 400 | `{ "error": "At least one channel must be specified" }` |
 | 400 | `{ "error": "pushXml must be a boolean" }` |
+| 400 | `{ "error": "autoStatus must be a boolean" }` |
+
+---
+
+### POST /api/live/events
+
+List events on a live server. This is a server-side proxy used by the admin UI to avoid browser CORS restrictions when querying a remote live server.
+
+**Request:**
+
+```json
+{
+  "serverUrl": "https://live.example.com",
+  "masterKey": "optional-admin-master-key"
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `serverUrl` | string | Yes | Live-mini server URL |
+| `masterKey` | string | No | Admin master key (lists all events on the server) |
+
+**Response:**
+
+```json
+{
+  "events": [
+    {
+      "eventId": "czech-cup-2025",
+      "mainTitle": "Czech Cup 2025",
+      "location": "Prague",
+      "discipline": "CSL",
+      "status": "running",
+      "apiKey": "abc123...",
+      "createdAt": "2025-01-02T09:00:00.000Z"
+    }
+  ]
+}
+```
+
+**Errors:**
+
+| Status | Response |
+|--------|----------|
+| 400 | `{ "error": "serverUrl is required" }` |
+
+---
+
+### POST /api/live/delete-event
+
+Delete an event on the remote live server, then disconnect and clear the saved local connection config. Uses the currently saved server URL and API key.
+
+**Request:**
+
+```json
+{
+  "eventId": "czech-cup-2025"
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `eventId` | string | Yes | Event to delete on the remote server |
+
+**Response:**
+
+```json
+{
+  "success": true
+}
+```
+
+**Errors:**
+
+| Status | Response |
+|--------|----------|
+| 400 | `{ "error": "eventId is required" }` |
+| 400 | `{ "error": "Not connected to any live server" }` |
+| 503 | `{ "error": "Live-Mini pusher not available" }` |
 
 ---
 
@@ -1931,7 +2122,7 @@ The same WebSocket connection used for real-time C123 data also delivers XML cha
   "type": "XmlChange",
   "timestamp": "2025-01-02T10:31:00.000Z",
   "data": {
-    "sections": ["Results", "StartList"],
+    "sections": ["Results", "Participants"],
     "checksum": "12345-67-89"
   }
 }
@@ -1939,7 +2130,7 @@ The same WebSocket connection used for real-time C123 data also delivers XML cha
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `sections` | string[] | Which sections changed: `Participants`, `Schedule`, `Results` |
+| `sections` | string[] | Which sections changed: `Participants`, `Schedule`, `Results`, `Classes` |
 | `checksum` | string | New file checksum |
 
 **Client workflow:**

--- a/docs/XML-FORMAT.md
+++ b/docs/XML-FORMAT.md
@@ -2,7 +2,7 @@
 
 This document describes the XML export format from Canoe123 (Siwidata) that C123 Server can read and serve via REST API.
 
-> **Complete documentation:** For exhaustive XML format documentation, see `analysis/c123-xml-format.md` in the analysis repository.
+> **Complete documentation:** For exhaustive XML format documentation, see `../c123-protocol-docs/c123-xml-format.md`.
 
 ---
 


### PR DESCRIPTION
## Proč

Při kontrole `docs/` proti reálnému kódu (`src/unified/UnifiedServer.ts`) vyšlo najevo, že REST a WebSocket dokumentace zaostává za implementací — chyběly endpointy, několik response tvarů nesedělo a WS protokol uváděl špatný port. Tento PR sjednocuje dokumentaci s kódem. Žádné změny kódu, jen `docs/`.

## Změny

### `REST-API.md`
- **Doplněny chybějící endpointy:** `GET /api/update-check`, `GET /api/xml/mismatch`, `POST /api/live/events`, `POST /api/live/delete-event`
- **`POST /api/c123/scoring`:** zdokumentován volitelný `raceId` (penalty korekce pro **dojeté** závodníky) vč. response a chybových stavů
- **`PATCH /api/live/config`:** doplněno pole `autoStatus` (request i response)
- **Opraveny response tvary podle kódu:**
  - `PUT /api/clients/:ip/config` → `{ ip, config, pushedToSessions }`
  - `DELETE /api/clients/:ip` → `{ success, ip, message }`
  - `POST /api/clients/:ip/refresh` → `{ success, ip, sessionsRefreshed, reason }`
- `GET /api/status` příklad verze sjednocen na `2.0.0`
- `XmlChange.sections` — doplněn `Classes`, odstraněn neplatný příklad `StartList`

### `C123-PROTOCOL.md`
- **Opraven port** WebSocket/REST na **27123** (bylo `3001`)
- Opraveny odkazy na nativní protokol na `../c123-protocol-docs/`
- **Doplněny zprávy:** `XmlMismatch`, `ScoringEvent`, `LiveStatus`, `ClientsUpdate`
- Vyjasněn rozdíl mezi scoreboard a admin (`?admin=1`) spojením a jejich sadami zpráv

### `XML-FORMAT.md`
- Opraven odkaz na nativní XML-format dokumentaci na `../c123-protocol-docs/`

## Mimo rozsah (follow-up)
- Úklid struktury `docs/` (přesun 2.9 MB `xboardtest02_jarni_v1.xml`, `discovery-client.ts`, `HIGHLIGHT_INVESTIGATION.md` mimo `docs/`; gitignore na `docs/superpowers/`).
- Checks / penalty-check persistence API zatím není na `main` (žije na `feat/penalty-check-persistence`), takže jeho dokumentace přijde s mergem té větve.

## Test plan
- [ ] Vizuální kontrola renderu Markdownu
- [ ] Ověření, že popsané endpointy/zprávy odpovídají `src/unified/UnifiedServer.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)