### PR TITLE
docs: correct REST endpoint paths in XML-FORMAT.md

### DIFF
--- a/docs/XML-FORMAT.md
+++ b/docs/XML-FORMAT.md
@@ -18,12 +18,16 @@ Canoe123 exports race data to an XML file that is continuously updated during th
 
 | Section | Description | REST Endpoint |
 |---------|-------------|---------------|
-| `Events` | Competition metadata (title, location, dates) | `/api/xml/events` |
+| `Events` | Competition metadata (title, location, dates) | *not exposed directly* — event name via `/api/event` |
 | `Participants` | Competitors and teams | `/api/xml/participants` |
-| `Classes` | Race categories | `/api/xml/classes` |
+| `Classes` | Race categories | *not exposed directly* — `classId` appears in `/api/xml/schedule` and `/api/xml/races` |
 | `Schedule` | Race schedule | `/api/xml/schedule` |
-| `Results` | Race results | `/api/xml/races/:raceId/results` |
-| `CourseData` | Course configuration (gates) | `/api/xml/course` |
+| `Results` | Race results | `/api/xml/races/:id/results` |
+| `CourseData` | Course configuration (gates) | `/api/xml/courses` |
+
+> The endpoint list above is a convenience index, not the API reference.
+> [REST-API.md](REST-API.md) is authoritative for routes, parameters and
+> response shapes.
 
 ---
 


### PR DESCRIPTION
## Problem

The "Main Sections" index in `docs/XML-FORMAT.md` pointed at routes that do not exist. Reported by @kubikaugustyn in #130 — half the paths in the document simply 404, which is a bad first experience for anyone integrating against the server.

## What was wrong

| Section | Documented | Reality |
|---------|-----------|---------|
| `CourseData` | `/api/xml/course` | `/api/xml/courses` |
| `Events` | `/api/xml/events` | never implemented |
| `Classes` | `/api/xml/classes` | never implemented |
| `Results` | `/api/xml/races/:raceId/results` | `/api/xml/races/:id/results` (cosmetic — param name differs from REST-API.md) |

Verified against the route registration in `src/unified/UnifiedServer.ts` (and `src/admin/AdminServer.ts`): the XML routes are `status`, `schedule`, `participants`, `races`, `races/:id`, `races/:id/startlist`, `races/:id/results`, `races/:id/results/:run`, `courses`, `mismatch`. There is no `events` and no `classes` route.

## Change

Fixed the `courses` path, aligned the results path with `REST-API.md`, and pointed `Events` / `Classes` at what actually serves that data (`/api/event` for the event name; `classId` is carried in the schedule and races payloads) instead of inventing endpoints.

Also added a note marking `REST-API.md` as the authoritative route reference, so this convenience index cannot silently drift again.

No behaviour change — docs only.

Closes #130