### PR TITLE
docs: results time/total are milliseconds, not centiseconds

### DIFF
--- a/docs/REST-API.md
+++ b/docs/REST-API.md
@@ -491,9 +491,9 @@ Get results for a specific race.
       "bib": "1",
       "startTime": "10:00:00",
       "status": "",
-      "time": 7899,
+      "time": 76990,
       "pen": 2,
-      "total": 7899,
+      "total": 78990,
       "rank": 1,
       "gates": "  0  0  2  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0",
       "participant": {
@@ -512,9 +512,9 @@ Get results for a specific race.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `time` | number | Run time in centiseconds (7899 = 78.99s) |
+| `time` | number | Run time in milliseconds (76990 = 76.99s) |
 | `pen` | number | Penalty in seconds |
-| `total` | number | Total time in centiseconds |
+| `total` | number | Total time in milliseconds (`time` + `pen` × 1000) |
 | `rank` | number | Position in results |
 | `status` | string | Empty for valid, `DSQ`, `DNS`, `DNF` for invalid |
 | `gates` | string | Space-separated per-gate penalties (0, 2, or 50) |
@@ -531,18 +531,18 @@ Get results for a specific race.
       "givenName": "Jakub",
       "club": "TJ DUKLA Praha",
       "run1": {
-        "time": 7899,
+        "time": 76990,
         "pen": 2,
-        "total": 7899,
+        "total": 78990,
         "rank": 1
       },
       "run2": {
-        "time": 7756,
+        "time": 77560,
         "pen": 0,
-        "total": 7756,
+        "total": 77560,
         "rank": 2
       },
-      "bestTotal": 7756,
+      "bestTotal": 77560,
       "bestRank": 1
     }
   ],
@@ -557,9 +557,9 @@ Get results for a specific race.
    ```json
    {
      "bib": "5",
-     "run1": { "time": 8156, "pen": 4, "total": 8196, "rank": 3 },
+     "run1": { "time": 81560, "pen": 4, "total": 85560, "rank": 3 },
      "run2": {},  // Not undefined!
-     "bestTotal": 8196,
+     "bestTotal": 85560,
      "bestRank": 3
    }
    ```
@@ -2181,21 +2181,32 @@ All endpoints return consistent error responses:
 
 ## Time Format
 
-Times in results are stored as **centiseconds** (1/100th of a second):
+The `time` and `total` fields in results are **milliseconds** — the raw value
+from the Canoe123 XML, passed through without conversion:
 
 | Value | Meaning |
 |-------|---------|
-| `7899` | 78.99 seconds |
-| `8156` | 81.56 seconds |
+| `76990` | 76.99 seconds |
+| `81560` | 81.56 seconds |
+
+`pen` is different: it is a penalty in **whole seconds**, so
+`total = time + pen × 1000`.
 
 To convert to display format:
 
 ```javascript
-function formatTime(centiseconds) {
-  const seconds = centiseconds / 100;
+function formatTime(milliseconds) {
+  const seconds = milliseconds / 1000;
   return seconds.toFixed(2);
 }
 ```
+
+> **Historical note:** this section previously claimed centiseconds. It was
+> wrong, and the mistake propagated — c123-penalty-check divided by 100 and
+> displayed every time 10× too large
+> ([#98](https://github.com/OpenCanoeTiming/c123-penalty-check/issues/98)).
+> Verify against real data before trusting a unit: in the XML samples a 76.99s
+> run is `<Time>76990</Time>` with `<Total>78990</Total>` and `<Pen>2</Pen>`.
 
 ---
 

--- a/docs/XML-FORMAT.md
+++ b/docs/XML-FORMAT.md
@@ -123,14 +123,14 @@ Canoe123 exports race data to an XML file that is continuously updated during th
   <Rank>1</Rank>
   <Bib>42</Bib>
   <Pen>2</Pen>
-  <Time>8532</Time>
-  <TotalTime>8732</TotalTime>
+  <Time>85320</Time>
+  <TotalTime>87320</TotalTime>
   <Gates>0,0,0,2,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0</Gates>
   <Status>0</Status>
 </Results>
 ```
 
-**Time Values:** All times are in centiseconds (1/100 second).
+**Time Values:** Run times are in milliseconds (85320 = 85.32 seconds).
 - `Time`: Run time without penalties
 - `TotalTime`: Run time + penalty seconds (each gate touch = 2s, miss = 50s)
 - `Pen`: Total penalty seconds


### PR DESCRIPTION
## Problem

`docs/REST-API.md` documented results `time` / `total` as **centiseconds**. They are **milliseconds** — the server passes the raw Canoe123 XML value through without conversion.

## Evidence

- Real XML (`c123-protocol-docs/samples/xboardtest02_jarni_v1.xml`): `<Time>76990</Time>`, `<Total>78990</Total>`, `<Pen>2</Pen>` for a 76.99s run. `total - time = 2000 = pen × 1000`.
- `src/service/XmlDataService.ts` — raw passthrough, no scaling.
- Clients that get it right divide by **1000** (`c123-scoreboard` `formatRestTime`, which even carries a comment saying the API types are wrong).
- The stale docs already caused a real bug: c123-penalty-check divided by 100 and displayed every time 10× too large (OpenCanoeTiming/c123-penalty-check#98, fixed in #99).

## Changes

| Location | Before | After |
|----------|--------|-------|
| `time` / `total` field table | "centiseconds (7899 = 78.99s)" | "milliseconds (76990 = 76.99s)", plus `total = time + pen × 1000` |
| Time Format section | "stored as centiseconds (1/100th)" | milliseconds, with the `pen`-is-seconds caveat spelled out |
| `formatTime()` snippet | `/ 100` | `/ 1000` |
| All example payloads | `"time": 7899, "pen": 2, "total": 7899` | `76990 / 2 / 78990` |
| `XML-FORMAT.md` Results | "All times are in centiseconds" + `<Time>8532</Time>` | milliseconds + `<Time>85320</Time>` |

Note the old examples had `total == time` while also carrying a non-zero `pen`, so they could not have come from a real payload — they are now internally consistent.

Added a short historical note in the Time Format section pointing at the penalty-check bug, so the next reader knows why the unit is called out so emphatically.

Docs only — `time` / `total` remain milliseconds, nothing in the server changes.

## Deliberately not in this PR

While verifying the above I found further inaccuracies in `XML-FORMAT.md`'s Results section, unrelated to time units and worth their own issue:

- `<TotalTime>` does not exist in any sample — the real element is `<Total>`.
- `Gates` is documented as comma-separated; real data is space-padded fixed-width (`"  0  0  2 ..."`).
- `Status` is documented as numeric `0/1/2/3`; real values are an empty element plus `DNS`, `DNF`, `DSQ` (and `RAL` in the 2024 LODM sample).

The WebSocket-side docs (`INTEGRATION.md`, `C123-PROTOCOL.md`, `SCOREBOARD-REQUIREMENTS.md`) also disagree with each other about the live `time` unit; that is a separate data path and is not touched here.

Closes #119