### PR TITLE
docs: correct XML and WebSocket format documentation against real samples

### DIFF
--- a/docs/C123-PROTOCOL.md
+++ b/docs/C123-PROTOCOL.md
@@ -99,12 +99,12 @@ Competitors currently on course (~2/second during racing).
 | `name` | string | Full name |
 | `club` | string | Club name |
 | `raceId` | string | Race identifier |
-| `gates` | string | Penalties per gate: `0`=clean, `2`=touch, `50`=miss |
+| `gates` | string | Penalties per gate, three space-padded characters each: `0`=clean, `2`=touch, `50`=miss |
 | `dtStart` | string | Start timestamp |
 | `dtFinish` | string\|null | Finish timestamp (null until finish) |
 | `pen` | number | Total penalty seconds |
-| `time` | string | Running time in centiseconds |
-| `total` | string | Total time (time + penalties) |
+| `time` | string | Running time in seconds, formatted (`"53"` while running, `"75.09"` once timed) |
+| `total` | string | Total time in seconds, formatted (time + penalties) |
 | `ttbDiff` | string | Difference to leader |
 | `rank` | number | Current rank |
 | `position` | number | Position on course (1 = closest to finish) |

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -1087,16 +1087,27 @@ if (message.type === 'Results' && message.data.isCurrent) {
 
 ### 4. Handle Time Formats
 
-Times are in centiseconds (1/100s). Convert for display:
+WebSocket times are **formatted second strings**, passed through from C123
+unchanged — not centiseconds, and not the milliseconds the REST API returns:
 
 ```typescript
-function formatTime(centiseconds: number): string {
-  const seconds = centiseconds / 100;
-  return seconds.toFixed(2);
+function formatTime(time: string): string {
+  return parseFloat(time).toFixed(2)
 }
 
-// 7899 -> "78.99"
+// "75.09" -> "75.09"   (finished run, two decimals)
+// "53"    -> "53.00"   (still running, C123 sends whole seconds)
 ```
+
+Watch the two data paths — they do not agree, and mixing them up has already
+caused a display bug:
+
+| Path | `time` / `total` | Example |
+|------|------------------|---------|
+| WebSocket (`OnCourse`, `Results`) | string, seconds | `"75.09"` |
+| REST (`/api/xml/races/:id/results`) | number, milliseconds | `76990` |
+
+See [REST-API.md](REST-API.md#time-format) for the REST side.
 
 ---
 

--- a/docs/REST-API.md
+++ b/docs/REST-API.md
@@ -636,9 +636,26 @@ Get course configuration data including gate setup and split positions.
 
 | Character | Meaning |
 |-----------|---------|
-| `N` | Normal gate (downstream) |
-| `R` | Reverse gate (upstream) |
-| `S` | Split point (timing checkpoint) |
+| `N` | Downstream gate ("normal", green) |
+| `R` | Upstream gate ("reverse", red) |
+| `I` | Split timing ("insert split") |
+| `S` | Sector delimiter ("gate section") |
+| `E` | Roll zone |
+| `D` | Kayak cross start |
+
+Only `N` and `R` are gates. `I`, `S`, `E` and `D` are markers between them, so
+a course string is longer than its gate count — `NNRNSNRNSRNNSNRNSNRNSRNSNRNSNRNS`
+is 32 characters but 24 gates. See
+`../c123-protocol-docs/c123-xml-format.md` for the source-verified list.
+
+> **Known defect:** the `splits` array above is derived from `S` and reports
+> the raw character index, not the gate number, so its values are wrong on any
+> course containing markers (32-character example above → `[5, 9, 13, ...]`
+> instead of `[4, 7, 10, ...]`). The example payload in this section predates
+> the current implementation and matches neither. Tracked in
+> [#148](https://github.com/OpenCanoeTiming/c123-server/issues/148); the field
+> will change once it is decided whether it should express sectors (`S`) or
+> split timing (`I`).
 
 **Use cases:**
 - c123-scoring uses splits for automatic gate grouping

--- a/docs/SCOREBOARD-REQUIREMENTS.md
+++ b/docs/SCOREBOARD-REQUIREMENTS.md
@@ -479,14 +479,14 @@ async function syncFromRestApi(): Promise<void> {
 
 ### OnCourse Time
 
-Running time in OnCourse is in **centiseconds** (1/100th of a second):
+Running time in OnCourse is a **formatted second string**, same as Results —
+C123 sends whole seconds while the competitor is on course and a two-decimal
+value once the run is timed:
 
 ```typescript
-// OnCourse time: "8115" = 81.15 seconds
-function formatRunningTime(centiseconds: string): string {
-  const cs = parseInt(centiseconds, 10);
-  const seconds = cs / 100;
-  return seconds.toFixed(2); // "81.15"
+// OnCourse time: "53" while running, "81.15" once finished
+function formatRunningTime(time: string): string {
+  return parseFloat(time).toFixed(2); // "53.00" / "81.15"
 }
 ```
 

--- a/docs/XML-FORMAT.md
+++ b/docs/XML-FORMAT.md
@@ -66,25 +66,37 @@ Canoe123 exports race data to an XML file that is continuously updated during th
 
 ```xml
 <Participants>
-  <Id>12345.K1M.ST</Id>
-  <ClassId>K1M-ST</ClassId>
-  <EventBib>42</EventBib>
-  <FirstName>Jan</FirstName>
-  <LastName>Novak</LastName>
+  <Id>60070.C1M.ZS</Id>
+  <ClassId>C1M-ZS</ClassId>
+  <EventBib>1</EventBib>
+  <ICFId>60070</ICFId>
+  <FamilyName>NOVAK</FamilyName>
+  <GivenName>Jan</GivenName>
+  <NOC>CZE</NOC>
   <Club>TJ Slavia Praha</Club>
-  <Nation>CZE</Nation>
+  <Year>2010</Year>
+  <CatId>ZS</CatId>
+  <IsTeam>false</IsTeam>
 </Participants>
 ```
+
+C2 crews carry a second paddler in `FamilyName2` / `GivenName2` / `ICFId2`;
+teams set `IsTeam` to `true` and reference their members in `Member1`-`Member3`.
 
 ### Classes (Race Categories)
 
 ```xml
 <Classes>
-  <ClassId>K1M-ST</ClassId>
-  <ShortName>K1m</ShortName>
-  <LongName>K1 Men - Medium Course</LongName>
-  <Boat>K1</Boat>
-  <Gender>M</Gender>
+  <ClassId>K1M-ZS</ClassId>
+  <Class>K1 Senior Men</Class>
+  <LongTitle>Kayak Senior Men</LongTitle>
+  <Categories>
+    <CatId>ZS</CatId>
+    <ClassId>K1M-ZS</ClassId>
+    <Category>Seniors</Category>
+    <FirstYear>1990</FirstYear>
+    <LastYear>2006</LastYear>
+  </Categories>
 </Classes>
 ```
 
@@ -92,65 +104,94 @@ Canoe123 exports race data to an XML file that is continuously updated during th
 
 ```xml
 <Schedule>
-  <RaceId>K1M_ST_BR1_6</RaceId>
-  <ClassId>K1M-ST</ClassId>
-  <Name>K1m - Medium Course - 1st Run</Name>
-  <MainTitle>K1m - Medium Course</MainTitle>
-  <SubTitle>1st Run</SubTitle>
-  <RaceType>BR1</RaceType>
-  <SortOrder>101</SortOrder>
-  <Status>5</Status>
+  <RaceId>K1M-ZS_BR1_25</RaceId>
+  <RaceOrder>10</RaceOrder>
+  <StartTime>2024-06-25T13:30:00+02:00</StartTime>
+  <Time>13:30:00</Time>
+  <ClassId>K1M-ZS</ClassId>
+  <DisId>BR1</DisId>
+  <FirstBib>1</FirstBib>
+  <StartInterval>1:00</StartInterval>
+  <JuryNr>1</JuryNr>
+  <CourseNr>1</CourseNr>
+  <RaceStatus>5</RaceStatus>
 </Schedule>
 ```
 
-**Race Status Values:**
+An optional `CustomTitle` carries a display name such as
+`K1m - short track - 1st run`; there are no separate `MainTitle` / `SubTitle`
+elements at schedule level.
+
+**RaceStatus Values:**
 | Value | Meaning |
 |-------|---------|
 | `0` | Not started |
 | `3` | Running |
+| `4` | Finished, results not yet official |
 | `5` | Finished |
 
-**Race Types:**
+Values `0`, `3`, `4` and `5` all occur in the reference samples. Treat any
+other value as unknown rather than assuming the list is exhaustive.
+
+**DisId (Run Type):**
 | Type | Description |
 |------|-------------|
 | `BR1` | Best Run - 1st Run |
 | `BR2` | Best Run - 2nd Run |
-| `FIN` | Final |
-| `SEM` | Semifinal |
-| `QUA` | Qualification |
+| `TSR` | Team Single Run |
+| `SR` | Single Run |
+| `XT` / `X4` / `XS` / `XF` / `XER` | Kayak cross phases (time trial, heats, semi, final, elimination) |
+
+`FIN`, `SEM` and `QUA` exist in Canoe123 for international formats but do not
+appear in any sample we hold. See `../c123-protocol-docs/c123-xml-format.md`
+for the full source-verified list.
 
 ### Results
 
 ```xml
 <Results>
   <RaceId>K1M_ST_BR1_6</RaceId>
-  <Rank>1</Rank>
-  <Bib>42</Bib>
+  <Id>12054.K1M_ST</Id>
+  <StartOrder>1</StartOrder>
+  <Bib>   1</Bib>
+  <Status />
+  <dtStart>08:30:10.780</dtStart>
+  <dtFinish>08:31:27.770</dtFinish>
+  <Time>76990</Time>
+  <Gates>  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  2</Gates>
   <Pen>2</Pen>
-  <Time>85320</Time>
-  <TotalTime>87320</TotalTime>
-  <Gates>0,0,0,2,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0</Gates>
-  <Status>0</Status>
+  <Total>78990</Total>
+  <Rnk>1</Rnk>
 </Results>
 ```
 
-**Time Values:** Run times are in milliseconds (85320 = 85.32 seconds).
+**Time Values:** Run times are in milliseconds (76990 = 76.99 seconds).
 - `Time`: Run time without penalties
-- `TotalTime`: Run time + penalty seconds (each gate touch = 2s, miss = 50s)
-- `Pen`: Total penalty seconds
+- `Total`: Run time + penalty seconds, i.e. `Time + Pen × 1000`
+- `Pen`: Total penalty in whole seconds (each gate touch = 2s, miss = 50s)
 
-**Gates Format:** Comma-separated values per gate:
+The rank element is `Rnk`, not `Rank`. BR2 rows additionally carry the first
+run under the `Prev*` elements (`PrevTime`, `PrevTotal`, `PrevPen`, ...).
+
+**Gates Format:** Fixed-width fields, three characters per gate, right-aligned
+and space-padded — *not* comma-separated. A course with 24 gates yields a
+72-character string, which is the reliable way to count gates:
 - `0` = Clean
 - `2` = Touch (2 second penalty)
 - `50` = Miss (50 second penalty)
 
-**Status Values:**
+**Status Values:** A string, not a number. Empty (`<Status />`) for a valid run:
+
 | Value | Meaning |
 |-------|---------|
-| `0` | Finished |
-| `1` | Did Not Start (DNS) |
-| `2` | Did Not Finish (DNF) |
-| `3` | Disqualified (DSQ) |
+| *(empty)* | Finished, valid run |
+| `DNS` | Did Not Start |
+| `DNF` | Did Not Finish |
+| `DSQ` | Disqualified |
+| `RAL` | Rallied / re-run (seen in the 2024 LODM sample) |
+
+This list is what occurs in the reference samples; treat unknown values as
+invalid rather than assuming completeness.
 
 ---
 
@@ -158,8 +199,14 @@ Canoe123 exports race data to an XML file that is continuously updated during th
 
 Czech races typically use "Best Run" format where competitors have two runs and their better result counts.
 
-**Race ID Pattern:** `{ClassId}_{Course}_{RunType}_{Gates}`
-- Example: `K1M_ST_BR1_6` = K1 Men, Short course, 1st Run, 6 gates
+**Race ID Pattern:** `{ClassId}_{DisId}_{DayOfMonth}`
+- Example: `K1M_ST_BR1_6` = class `K1M_ST`, 1st run, 6th day of the month
+- Example: `K1M-ZS_BR1_25` = class `K1M-ZS`, 1st run, 25th day of the month
+
+The trailing number is the day of month, not a gate count: in
+`xboardtest02_jarni_v1.xml` race `K1M_ST_BR1_6` starts `2024-04-06`, and in
+`2024-LODM-fin.xml` race `K1M-ZS_BR1_25` starts `2024-06-25`. Do not parse it
+for anything else — use the `Gates` field width to count gates.
 
 **Important:** BR2 Results may contain BR1 values when BR1 was better. See [C123-PROTOCOL.md](C123-PROTOCOL.md#br1br2-two-run-handling) for details.
 
@@ -168,8 +215,11 @@ Czech races typically use "Best Run" format where competitors have two runs and 
 ## Sample Files
 
 For complete sample XML files, see:
-- `analysis/captures/xboardtest02_jarni_v1.xml` - Test data with multiple categories
-- `analysis/captures/2024-LODM-fin.xml` - Real competition data
+- `../c123-protocol-docs/samples/xboardtest02_jarni_v1.xml` - Test data with multiple categories
+- `../c123-protocol-docs/samples/2024-LODM-fin.xml` - Real competition data (incl. kayak cross and teams)
+
+Every example and value list in this document was checked against those two
+files.
 
 ---
 


### PR DESCRIPTION
## Why

Follow-up to #130 and #119. While fixing those I noticed the Results section of `XML-FORMAT.md` documented `<TotalTime>`, comma-separated `Gates` and numeric `Status` — none of which exist. Checking the rest of the file showed the problem was not isolated: most examples used element names that appear in no sample.

Every example and value list in this PR was verified against `../c123-protocol-docs/samples/xboardtest02_jarni_v1.xml` and `2024-LODM-fin.xml`.

## XML-FORMAT.md

| Section | Documented | Actual |
|---------|-----------|--------|
| Participants | `FirstName`, `LastName`, `Nation` | `GivenName`, `FamilyName`, `NOC` |
| Classes | `ShortName`, `LongName`, `Boat`, `Gender` | `Class`, `LongTitle`, nested `Categories` |
| Schedule | `Name`, `MainTitle`, `SubTitle`, `RaceType`, `SortOrder`, `Status` | `CustomTitle`, `DisId`, `RaceOrder`, `RaceStatus` (+ `StartTime`, `FirstBib`, `StartInterval`, `JuryNr`, `CourseNr`, all missing before) |
| Results | `Rank`, `TotalTime` | `Rnk`, `Total` |
| Results `Gates` | comma-separated | three space-padded characters per gate |
| Results `Status` | numeric `0`/`1`/`2`/`3` | string: empty, `DNS`, `DNF`, `DSQ`, `RAL` |
| `RaceStatus` | `0`, `3`, `5` | `4` also occurs |
| `DisId` | `BR1`, `BR2`, `FIN`, `SEM`, `QUA` | `BR1`, `BR2`, `TSR`, `SR`, `XT`/`X4`/`XS`/`XF`/`XER`; `FIN`/`SEM`/`QUA` appear in no sample |
| Sample files | `analysis/captures/…` | directory does not exist; they are in `../c123-protocol-docs/samples/` |

Also corrected the RaceId pattern. It was documented as `{ClassId}_{Course}_{RunType}_{Gates}` with `K1M_ST_BR1_6` read as "6 gates". The trailing number is the **day of month**: `K1M_ST_BR1_6` starts `2024-04-06`, and `K1M-ZS_BR1_25` starts `2024-06-25`. Since that was the documented way to get a gate count, the doc now points at the `Gates` field width instead (72 characters = 24 gates).

The `Gates` field width is worth calling out separately — it is the one reliable gate count in the format, and `courseConfig` length is not (see #148).

## WebSocket time unit

The same field was documented three different ways:

- `INTEGRATION.md` — "centiseconds (1/100s)", `/100`, `7899 -> "78.99"`
- `SCOREBOARD-REQUIREMENTS.md` — OnCourse "centiseconds", `"8115" = 81.15`, but Results "seconds (decimal string)" two paragraphs later
- `C123-PROTOCOL.md` — "Running time in centiseconds"

It is a **formatted second string**. Evidence:

- `src/protocol/parser-types.ts:31` — *"Running time as formatted string (e.g., `75.09`)"*; the parser passes the C123 attribute through untouched (`xml-parser.ts:198`).
- `c123-protocol-docs/c123-protocol.md:933` — recorded trace: `oncourse: Time="53" (running time, whole second)`.
- `src/live/LiveTransformer.ts:338` — `parseFormattedTimeToCentiseconds` does `parseFloat(time) * 100`, documented as `"79.99" → 7999`. It would be a no-op if the input were already centiseconds.

So C123 sends whole seconds while a competitor is on course and two decimals once the run is timed. All three documents now agree, and the WebSocket-vs-REST split is stated explicitly, because that is exactly the confusion that produced the penalty-check 10×-times bug behind #119:

| Path | `time` / `total` | Example |
|------|------------------|---------|
| WebSocket | string, seconds | `"75.09"` |
| REST | number, milliseconds | `76990` |

## REST-API.md

The CourseConfig character table listed only `N`, `R`, `S` and called `S` a split point. Added `I`, `E`, `D` and the correct meanings, matching the table just landed in c123-protocol-docs#5, plus the note that only `N` and `R` are gates.

Also flagged the `splits` array as known-wrong inline rather than leaving it looking authoritative — it reports character indices instead of gate numbers, and the example payload matches neither the format nor the current implementation. Tracked in #148; not fixed here, since the field's meaning is still undecided.

Docs only — no code changes, no behaviour change.